### PR TITLE
LPD-79040 Fix duplication of shipment entries in order shipments page

### DIFF
--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceShipmentFinder.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/persistence/CommerceShipmentFinder.java
@@ -13,14 +13,4 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface CommerceShipmentFinder {
-
-	public int countByCommerceOrderId(long commerceOrderId);
-
-	public java.util.List<com.liferay.commerce.model.CommerceShipment>
-		findByCommerceOrderId(long commerceOrderId, int start, int end);
-
-	public int[] findCommerceShipmentStatusesByCommerceOrderId(
-		long commerceOrderId);
-
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-86082515

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceShipmentLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceShipmentLocalServiceImpl.java
@@ -14,7 +14,10 @@ import com.liferay.commerce.exception.CommerceShipmentStatusException;
 import com.liferay.commerce.model.CommerceAddress;
 import com.liferay.commerce.model.CommerceOrder;
 import com.liferay.commerce.model.CommerceOrderItem;
+import com.liferay.commerce.model.CommerceOrderItemTable;
 import com.liferay.commerce.model.CommerceShipment;
+import com.liferay.commerce.model.CommerceShipmentItemTable;
+import com.liferay.commerce.model.CommerceShipmentTable;
 import com.liferay.commerce.model.CommerceShippingMethod;
 import com.liferay.commerce.model.attributes.provider.CommerceModelAttributesProvider;
 import com.liferay.commerce.service.CommerceAddressLocalService;
@@ -24,6 +27,7 @@ import com.liferay.commerce.service.CommerceShipmentItemLocalService;
 import com.liferay.commerce.service.CommerceShippingMethodLocalService;
 import com.liferay.commerce.service.base.CommerceShipmentLocalServiceBaseImpl;
 import com.liferay.expando.kernel.service.ExpandoRowLocalService;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -263,8 +267,27 @@ public class CommerceShipmentLocalServiceImpl
 	public List<CommerceShipment> getCommerceShipments(
 		long commerceOrderId, int start, int end) {
 
-		return commerceShipmentFinder.findByCommerceOrderId(
-			commerceOrderId, start, end);
+		return dslQuery(
+			DSLQueryFactoryUtil.selectDistinct(
+				CommerceShipmentTable.INSTANCE
+			).from(
+				CommerceShipmentTable.INSTANCE
+			).leftJoinOn(
+				CommerceShipmentItemTable.INSTANCE,
+				CommerceShipmentTable.INSTANCE.commerceShipmentId.eq(
+					CommerceShipmentItemTable.INSTANCE.commerceShipmentId)
+			).innerJoinON(
+				CommerceOrderItemTable.INSTANCE,
+				CommerceOrderItemTable.INSTANCE.commerceOrderItemId.eq(
+					CommerceShipmentItemTable.INSTANCE.commerceOrderItemId)
+			).where(
+				CommerceOrderItemTable.INSTANCE.commerceOrderId.eq(
+					commerceOrderId)
+			).orderBy(
+				CommerceShipmentTable.INSTANCE.createDate.descending()
+			).limit(
+				start, end
+			));
 	}
 
 	@Override
@@ -313,7 +336,23 @@ public class CommerceShipmentLocalServiceImpl
 
 	@Override
 	public int getCommerceShipmentsCount(long commerceOrderId) {
-		return commerceShipmentFinder.countByCommerceOrderId(commerceOrderId);
+		return dslQueryCount(
+			DSLQueryFactoryUtil.countDistinct(
+				CommerceShipmentTable.INSTANCE.commerceShipmentId
+			).from(
+				CommerceShipmentTable.INSTANCE
+			).leftJoinOn(
+				CommerceShipmentItemTable.INSTANCE,
+				CommerceShipmentTable.INSTANCE.commerceShipmentId.eq(
+					CommerceShipmentItemTable.INSTANCE.commerceShipmentId)
+			).innerJoinON(
+				CommerceOrderItemTable.INSTANCE,
+				CommerceOrderItemTable.INSTANCE.commerceOrderItemId.eq(
+					CommerceShipmentItemTable.INSTANCE.commerceOrderItemId)
+			).where(
+				CommerceOrderItemTable.INSTANCE.commerceOrderId.eq(
+					commerceOrderId)
+			));
 	}
 
 	@Override
@@ -356,8 +395,25 @@ public class CommerceShipmentLocalServiceImpl
 	public int[] getCommerceShipmentStatusesByCommerceOrderId(
 		long commerceOrderId) {
 
-		return commerceShipmentFinder.
-			findCommerceShipmentStatusesByCommerceOrderId(commerceOrderId);
+		List<Integer> commerceShipmentStatuses = dslQuery(
+			DSLQueryFactoryUtil.selectDistinct(
+				CommerceShipmentTable.INSTANCE.status
+			).from(
+				CommerceShipmentTable.INSTANCE
+			).leftJoinOn(
+				CommerceShipmentItemTable.INSTANCE,
+				CommerceShipmentTable.INSTANCE.commerceShipmentId.eq(
+					CommerceShipmentItemTable.INSTANCE.commerceShipmentId)
+			).innerJoinON(
+				CommerceOrderItemTable.INSTANCE,
+				CommerceOrderItemTable.INSTANCE.commerceOrderItemId.eq(
+					CommerceShipmentItemTable.INSTANCE.commerceOrderItemId)
+			).where(
+				CommerceOrderItemTable.INSTANCE.commerceOrderId.eq(
+					commerceOrderId)
+			));
+
+		return ArrayUtil.toIntArray(commerceShipmentStatuses);
 	}
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceShipmentFinderImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceShipmentFinderImpl.java
@@ -5,23 +5,9 @@
 
 package com.liferay.commerce.service.persistence.impl;
 
-import com.liferay.commerce.model.CommerceShipment;
-import com.liferay.commerce.model.impl.CommerceShipmentImpl;
 import com.liferay.commerce.service.persistence.CommerceShipmentFinder;
-import com.liferay.portal.dao.orm.custom.sql.CustomSQL;
-import com.liferay.portal.kernel.dao.orm.QueryPos;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.dao.orm.SQLQuery;
-import com.liferay.portal.kernel.dao.orm.Session;
-import com.liferay.portal.kernel.dao.orm.Type;
-import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.util.ArrayUtil;
-
-import java.util.Iterator;
-import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alec Sloan
@@ -29,120 +15,4 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = CommerceShipmentFinder.class)
 public class CommerceShipmentFinderImpl
 	extends CommerceShipmentFinderBaseImpl implements CommerceShipmentFinder {
-
-	public static final String COUNT_BY_COMMERCE_ORDER_ID =
-		CommerceShipmentFinder.class.getName() + ".countByCommerceOrderId";
-
-	public static final String FIND_BY_COMMERCE_ORDER_ID =
-		CommerceShipmentFinder.class.getName() + ".findByCommerceOrderId";
-
-	public static final String
-		FIND_COMMERCE_SHIPMENT_STATUSES_BY_COMMERCE_ORDER_ID =
-			CommerceShipmentFinder.class.getName() +
-				".findCommerceShipmentStatusesByCommerceOrderId";
-
-	@Override
-	public int countByCommerceOrderId(long commerceOrderId) {
-		Session session = null;
-
-		try {
-			session = openSession();
-
-			String sql = _customSQL.get(getClass(), COUNT_BY_COMMERCE_ORDER_ID);
-
-			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
-
-			sqlQuery.addScalar(COUNT_COLUMN_NAME, Type.LONG);
-
-			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
-
-			queryPos.add(commerceOrderId);
-
-			Iterator<Long> iterator = sqlQuery.iterate();
-
-			if (iterator.hasNext()) {
-				Long count = iterator.next();
-
-				if (count != null) {
-					return count.intValue();
-				}
-			}
-
-			return 0;
-		}
-		catch (Exception exception) {
-			throw new SystemException(exception);
-		}
-		finally {
-			closeSession(session);
-		}
-	}
-
-	@Override
-	public List<CommerceShipment> findByCommerceOrderId(
-		long commerceOrderId, int start, int end) {
-
-		Session session = null;
-
-		try {
-			session = openSession();
-
-			String sql = _customSQL.get(getClass(), FIND_BY_COMMERCE_ORDER_ID);
-
-			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
-
-			sqlQuery.addEntity("CommerceShipment", CommerceShipmentImpl.class);
-
-			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
-
-			queryPos.add(commerceOrderId);
-
-			return (List<CommerceShipment>)QueryUtil.list(
-				sqlQuery, getDialect(), start, end);
-		}
-		catch (Exception exception) {
-			throw new SystemException(exception);
-		}
-		finally {
-			closeSession(session);
-		}
-	}
-
-	@Override
-	public int[] findCommerceShipmentStatusesByCommerceOrderId(
-		long commerceOrderId) {
-
-		Session session = null;
-
-		try {
-			session = openSession();
-
-			String sql = _customSQL.get(
-				getClass(),
-				FIND_COMMERCE_SHIPMENT_STATUSES_BY_COMMERCE_ORDER_ID);
-
-			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
-
-			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
-
-			queryPos.add(commerceOrderId);
-
-			List<Integer> commerceShipmentStatuses =
-				(List<Integer>)QueryUtil.list(
-					sqlQuery, getDialect(), QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS);
-
-			return ArrayUtil.toIntArray(commerceShipmentStatuses);
-		}
-		catch (Exception exception) {
-			throw new SystemException(exception);
-		}
-		finally {
-			closeSession(session);
-		}
-	}
-
-	@Reference
-	private CustomSQL _customSQL;
-
 }

--- a/modules/apps/commerce/commerce-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/commerce/commerce-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -137,54 +137,6 @@
 				(CommerceOrder.status <> ?)
 		]]>
 	</sql>
-	<sql id="com.liferay.commerce.service.persistence.CommerceShipmentFinder.countByCommerceOrderId">
-		<![CDATA[
-			SELECT
-				COUNT(CommerceShipment.commerceShipmentId) AS COUNT_VALUE
-			FROM
-				CommerceShipment
-			LEFT JOIN
-				CommerceShipmentItem ON
-					CommerceShipmentItem.commerceShipmentId = CommerceShipment.commerceShipmentId
-			INNER JOIN
-				CommerceOrderItem ON
-					CommerceOrderItem.commerceOrderItemId = CommerceShipmentItem.commerceOrderItemId
-			WHERE
-				CommerceOrderItem.commerceOrderId = ?
-		]]>
-	</sql>
-	<sql id="com.liferay.commerce.service.persistence.CommerceShipmentFinder.findByCommerceOrderId">
-		<![CDATA[
-			SELECT
-				{CommerceShipment.*}
-			FROM
-				CommerceShipment
-			LEFT JOIN
-				CommerceShipmentItem ON
-					CommerceShipmentItem.commerceShipmentId = CommerceShipment.commerceShipmentId
-			INNER JOIN
-				CommerceOrderItem ON
-					CommerceOrderItem.commerceOrderItemId = CommerceShipmentItem.commerceOrderItemId
-			WHERE
-				CommerceOrderItem.commerceOrderId = ?
-		]]>
-	</sql>
-	<sql id="com.liferay.commerce.service.persistence.CommerceShipmentFinder.findCommerceShipmentStatusesByCommerceOrderId">
-		<![CDATA[
-			SELECT
-				DISTINCT CommerceShipment.status
-			FROM
-				CommerceShipment
-			LEFT JOIN
-				CommerceShipmentItem ON
-					CommerceShipmentItem.commerceShipmentId = CommerceShipment.commerceShipmentId
-			INNER JOIN
-				CommerceOrderItem ON
-					CommerceOrderItem.commerceOrderItemId = CommerceShipmentItem.commerceOrderItemId
-			WHERE
-				CommerceOrderItem.commerceOrderId = ?
-		]]>
-	</sql>
 	<sql id="com.liferay.commerce.service.persistence.CommerceShipmentItemFinder.findByCommerceOrderItemId">
 		<![CDATA[
 			SELECT

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/shipment/test/CommerceShipmentLocalServiceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/shipment/test/CommerceShipmentLocalServiceTest.java
@@ -1,0 +1,194 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.commerce.shipment.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.constants.CommerceShipmentConstants;
+import com.liferay.commerce.currency.model.CommerceCurrency;
+import com.liferay.commerce.currency.test.util.CommerceCurrencyTestUtil;
+import com.liferay.commerce.inventory.model.CommerceInventoryWarehouse;
+import com.liferay.commerce.model.CommerceAddress;
+import com.liferay.commerce.model.CommerceOrder;
+import com.liferay.commerce.model.CommerceShipment;
+import com.liferay.commerce.model.CommerceShippingFixedOption;
+import com.liferay.commerce.model.CommerceShippingMethod;
+import com.liferay.commerce.product.model.CPInstance;
+import com.liferay.commerce.product.model.CommerceChannel;
+import com.liferay.commerce.service.CommerceOrderLocalService;
+import com.liferay.commerce.service.CommerceShipmentLocalService;
+import com.liferay.commerce.shipment.test.util.CommerceShipmentTestUtil;
+import com.liferay.commerce.test.util.CommerceInventoryTestUtil;
+import com.liferay.commerce.test.util.CommerceTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Giuseppe Pelusi
+ */
+@RunWith(Arquillian.class)
+public class CommerceShipmentLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.getPermissionCheckerMethodTestRule());
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+		_user = UserTestUtil.addUser();
+
+		_commerceCurrency = CommerceCurrencyTestUtil.addCommerceCurrency(
+			_group.getCompanyId());
+
+		_commerceChannel = CommerceTestUtil.addCommerceChannel(
+			_user.getUserId(), _group.getGroupId(), _commerceCurrency.getCode());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		for (CommerceOrder commerceOrder : _commerceOrders) {
+			CommerceTestUtil.deleteCommerceOrder(
+				commerceOrder.getCommerceOrderId());
+		}
+
+		CommerceTestUtil.deleteCommerceChannel(_commerceChannel);
+
+		CommerceCurrencyTestUtil.deleteCommerceCurrency(_commerceCurrency);
+
+		UserTestUtil.deleteUser(_user);
+
+		GroupTestUtil.deleteGroup(_group);
+	}
+
+	@Test
+	public void testShipmentsAreNotDuplicatedForEachOrderItem() throws Exception {
+		CommerceOrder commerceOrder = CommerceTestUtil.addB2CCommerceOrder(
+			_user.getUserId(), _commerceChannel.getGroupId(),
+			_commerceCurrency.getCommerceCurrencyId());
+
+		CommerceInventoryWarehouse commerceInventoryWarehouse =
+			CommerceInventoryTestUtil.addCommerceInventoryWarehouse();
+
+		CommerceTestUtil.addWarehouseCommerceChannelRel(
+			commerceInventoryWarehouse.getCommerceInventoryWarehouseId(),
+			_commerceChannel.getCommerceChannelId());
+
+		for (int i = 0; i < 7; i++) {
+			CPInstance cpInstance = CommerceTestUtil.createCPInstance(
+				_user.getUserId(), _group.getGroupId());
+
+			CommerceTestUtil.addCommerceOrderItem(
+				commerceOrder.getCommerceOrderId(),
+				cpInstance.getCPInstanceId(), BigDecimal.ONE);
+
+			CommerceInventoryTestUtil.addCommerceInventoryWarehouseItem(
+				_user.getUserId(), commerceInventoryWarehouse,
+				BigDecimal.valueOf(100), cpInstance.getSku(), StringPool.BLANK);
+		}
+
+		int orderStatusIndex = RandomTestUtil.randomInt(
+			0, CommerceShipmentConstants.ALLOWED_ORDER_STATUSES.length - 1);
+
+		int orderStatus =
+			CommerceShipmentConstants.ALLOWED_ORDER_STATUSES[orderStatusIndex];
+
+		commerceOrder.setOrderStatus(orderStatus);
+
+		commerceOrder = _commerceOrderLocalService.getCommerceOrder(
+			commerceOrder.getCommerceOrderId());
+
+		CommerceAddress billingCommerceAddress =
+			CommerceTestUtil.addUserCommerceAddress(
+				_commerceChannel.getGroupId(), _user.getUserId());
+		CommerceAddress shippingCommerceAddress =
+			CommerceTestUtil.addUserCommerceAddress(
+				_commerceChannel.getGroupId(), _user.getUserId());
+
+		commerceOrder.setBillingAddressId(
+			billingCommerceAddress.getCommerceAddressId());
+		commerceOrder.setShippingAddressId(
+			shippingCommerceAddress.getCommerceAddressId());
+
+		BigDecimal amount = BigDecimal.valueOf(RandomTestUtil.nextDouble());
+
+		CommerceShippingMethod commerceShippingMethod =
+			CommerceTestUtil.addFixedRateCommerceShippingMethod(
+				_user.getUserId(), _commerceChannel.getGroupId(), amount);
+
+		commerceOrder.setCommerceShippingMethodId(
+			commerceShippingMethod.getCommerceShippingMethodId());
+
+		CommerceShippingFixedOption commerceShippingFixedOption =
+			CommerceTestUtil.addCommerceShippingFixedOption(
+				commerceShippingMethod, amount);
+
+		commerceOrder.setShippingAmount(
+			commerceShippingFixedOption.getAmount());
+		commerceOrder.setShippingOptionName(
+			commerceShippingFixedOption.getNameCurrentValue());
+
+		_commerceOrderLocalService.updateCommerceOrder(commerceOrder);
+
+		_commerceOrders.add(commerceOrder);
+
+		CommerceShipment commerceShipment =
+			CommerceShipmentTestUtil.createOrderShipment(
+				commerceOrder.getGroupId(), commerceOrder.getCommerceOrderId(),
+				commerceInventoryWarehouse.getCommerceInventoryWarehouseId());
+
+		List<CommerceShipment> commerceShipments =
+			_commerceShipmentLocalService.getCommerceShipments(
+				commerceOrder.getCommerceOrderId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		Assert.assertEquals(1, commerceShipments.size());
+		Assert.assertEquals(
+			commerceShipment.getCommerceShipmentId(),
+			commerceShipments.get(0).getCommerceShipmentId());
+
+		int count = _commerceShipmentLocalService.getCommerceShipmentsCount(
+			commerceOrder.getCommerceOrderId());
+
+		Assert.assertEquals(1, count);
+	}
+
+	private CommerceChannel _commerceChannel;
+	private CommerceCurrency _commerceCurrency;
+	private List<CommerceOrder> _commerceOrders = new ArrayList<>();
+	private Group _group;
+	private User _user;
+
+	@Inject
+	private CommerceOrderLocalService _commerceOrderLocalService;
+
+	@Inject
+	private CommerceShipmentLocalService _commerceShipmentLocalService;
+
+}


### PR DESCRIPTION
This PR fixes the duplication of shipment entries in the order's shipments page (LPD-79040).

The following changes were made:
- Migrated legacy SQL queries for commerce shipments to `CommerceShipmentLocalServiceImpl` using `DSLQuery`.
- Added `DISTINCT` to the shipment queries to ensure each shipment is only listed once.
- Removed the old SQL entries from `default.xml` and entirely removed `CommerceShipmentFinderImpl` and `CommerceShipmentFinder` interface.
- Added `CommerceShipmentLocalServiceTest` to verify that shipments are no longer duplicated, which includes:
  - A test case reproducing the exact bug by adding 7 different SKUs (CPInstances) to an order as specified in the Jira reproduction steps.

Jira Ticket: https://liferay.atlassian.net/browse/LPD-79040