### PR TITLE
LPD-85260 expired SKUs can appear in product details portlet

### DIFF
--- a/modules/apps/commerce/commerce-product-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-product-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Product API
 Bundle-SymbolicName: com.liferay.commerce.product.api
-Bundle-Version: 97.0.1
+Bundle-Version: 97.1.0
 Export-Package:\
 	com.liferay.commerce.product.availability,\
 	com.liferay.commerce.product.catalog,\

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPDefinitionOptionValueRelLocalService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPDefinitionOptionValueRelLocalService.java
@@ -275,6 +275,11 @@ public interface CPDefinitionOptionValueRelLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<CPDefinitionOptionValueRel>
+		getApprovedCPInstanceCPDefinitionOptionValueRels(
+			long cpDefinitionOptionRelId);
+
 	/**
 	 * Returns the cp definition option value rel with the primary key.
 	 *
@@ -482,4 +487,4 @@ public interface CPDefinitionOptionValueRelLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1558778191
+// LIFERAY-SERVICE-BUILDER-HASH:1310312746

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPDefinitionOptionValueRelLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPDefinitionOptionValueRelLocalServiceUtil.java
@@ -311,6 +311,14 @@ public class CPDefinitionOptionValueRelLocalServiceUtil {
 		return getService().getActionableDynamicQuery();
 	}
 
+	public static List<CPDefinitionOptionValueRel>
+		getApprovedCPInstanceCPDefinitionOptionValueRels(
+			long cpDefinitionOptionRelId) {
+
+		return getService().getApprovedCPInstanceCPDefinitionOptionValueRels(
+			cpDefinitionOptionRelId);
+	}
+
 	/**
 	 * Returns the cp definition option value rel with the primary key.
 	 *
@@ -605,4 +613,4 @@ public class CPDefinitionOptionValueRelLocalServiceUtil {
 			CPDefinitionOptionValueRelLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-855098305
+// LIFERAY-SERVICE-BUILDER-HASH:-1324743478

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPDefinitionOptionValueRelLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPDefinitionOptionValueRelLocalServiceWrapper.java
@@ -357,6 +357,16 @@ public class CPDefinitionOptionValueRelLocalServiceWrapper
 			getActionableDynamicQuery();
 	}
 
+	@Override
+	public java.util.List<CPDefinitionOptionValueRel>
+		getApprovedCPInstanceCPDefinitionOptionValueRels(
+			long cpDefinitionOptionRelId) {
+
+		return _cpDefinitionOptionValueRelLocalService.
+			getApprovedCPInstanceCPDefinitionOptionValueRels(
+				cpDefinitionOptionRelId);
+	}
+
 	/**
 	 * Returns the cp definition option value rel with the primary key.
 	 *
@@ -728,4 +738,4 @@ public class CPDefinitionOptionValueRelLocalServiceWrapper
 		_cpDefinitionOptionValueRelLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-223896826
+// LIFERAY-SERVICE-BUILDER-HASH:-1095163404

--- a/modules/apps/commerce/commerce-product-api/src/main/resources/com/liferay/commerce/product/service/packageinfo
+++ b/modules/apps/commerce/commerce-product-api/src/main/resources/com/liferay/commerce/product/service/packageinfo
@@ -1,1 +1,1 @@
-version 57.0.0
+version 57.1.0

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelLocalServiceImpl.java
@@ -18,7 +18,6 @@ import com.liferay.commerce.product.helper.CPCollectionProviderHelper;
 import com.liferay.commerce.product.internal.util.CPDefinitionLocalServiceCircularDependencyUtil;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPDefinitionOptionRel;
-import com.liferay.commerce.product.model.CPDefinitionOptionRelTable;
 import com.liferay.commerce.product.model.CPDefinitionOptionValueRel;
 import com.liferay.commerce.product.model.CPDefinitionOptionValueRelTable;
 import com.liferay.commerce.product.model.CPInstance;
@@ -501,13 +500,14 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 								WorkflowConstants.STATUS_APPROVED)
 						)
 				).orderBy(
-					CPDefinitionOptionValueRelTable.INSTANCE.priority.ascending(),
-					CPDefinitionOptionValueRelTable.INSTANCE.createDate.ascending()
-				)
-			);
+					CPDefinitionOptionValueRelTable.INSTANCE.priority.
+						ascending(),
+					CPDefinitionOptionValueRelTable.INSTANCE.createDate.
+						ascending()
+				));
 
 		if (cpDefinitionOptionValueRels.isEmpty()) {
-			return null;
+			return Collections.emptyList();
 		}
 
 		return cpDefinitionOptionValueRels;

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelLocalServiceImpl.java
@@ -40,6 +40,7 @@ import com.liferay.expando.kernel.service.ExpandoRowLocalService;
 import com.liferay.info.pagination.Pagination;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
@@ -89,6 +90,7 @@ import java.math.BigDecimal;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -475,42 +477,38 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 		getApprovedCPInstanceCPDefinitionOptionValueRels(
 			long cpDefinitionOptionRelId) {
 
-		List<CPDefinitionOptionValueRel> cpDefinitionOptionValueRels =
-			cpDefinitionOptionValueRelPersistence.dslQuery(
-				DSLQueryFactoryUtil.select(
-					CPDefinitionOptionValueRelTable.INSTANCE
-				).from(
-					CPDefinitionOptionValueRelTable.INSTANCE
-				).innerJoinON(
-					CPInstanceOptionValueRelTable.INSTANCE,
-					CPInstanceOptionValueRelTable.INSTANCE.
-						CPDefinitionOptionValueRelId.eq(
-							CPDefinitionOptionValueRelTable.INSTANCE.
-								CPDefinitionOptionValueRelId)
-				).innerJoinON(
-					CPInstanceTable.INSTANCE,
-					CPInstanceTable.INSTANCE.CPInstanceId.eq(
-						CPInstanceOptionValueRelTable.INSTANCE.CPInstanceId)
-				).where(
-					CPDefinitionOptionValueRelTable.INSTANCE.
-						CPDefinitionOptionRelId.eq(
-							cpDefinitionOptionRelId
-						).and(
-							CPInstanceTable.INSTANCE.status.eq(
-								WorkflowConstants.STATUS_APPROVED)
-						)
-				).orderBy(
-					CPDefinitionOptionValueRelTable.INSTANCE.priority.
-						ascending(),
-					CPDefinitionOptionValueRelTable.INSTANCE.createDate.
-						ascending()
-				));
-
-		if (cpDefinitionOptionValueRels.isEmpty()) {
-			return Collections.emptyList();
-		}
-
-		return cpDefinitionOptionValueRels;
+		return cpDefinitionOptionValueRelPersistence.dslQuery(
+			DSLQueryFactoryUtil.selectDistinct(
+				CPDefinitionOptionValueRelTable.INSTANCE
+			).from(
+				CPDefinitionOptionValueRelTable.INSTANCE
+			).innerJoinON(
+				CPInstanceOptionValueRelTable.INSTANCE,
+				CPInstanceOptionValueRelTable.INSTANCE.
+					CPDefinitionOptionValueRelId.eq(
+						CPDefinitionOptionValueRelTable.INSTANCE.
+							CPDefinitionOptionValueRelId)
+			).innerJoinON(
+				CPInstanceTable.INSTANCE,
+				CPInstanceTable.INSTANCE.CPInstanceId.eq(
+					CPInstanceOptionValueRelTable.INSTANCE.CPInstanceId)
+			).where(
+				CPDefinitionOptionValueRelTable.INSTANCE.
+					CPDefinitionOptionRelId.eq(
+						cpDefinitionOptionRelId
+					).and(
+						CPInstanceTable.INSTANCE.status.eq(
+							WorkflowConstants.STATUS_APPROVED)
+					).and(
+						Predicate.or(
+							CPInstanceTable.INSTANCE.expirationDate.isNull(),
+							CPInstanceTable.INSTANCE.expirationDate.gt(
+								new Date()))
+					)
+			).orderBy(
+				CPDefinitionOptionValueRelTable.INSTANCE.priority.ascending(),
+				CPDefinitionOptionValueRelTable.INSTANCE.createDate.ascending()
+			));
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelLocalServiceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.commerce.product.helper.CPCollectionProviderHelper;
 import com.liferay.commerce.product.internal.util.CPDefinitionLocalServiceCircularDependencyUtil;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPDefinitionOptionRel;
+import com.liferay.commerce.product.model.CPDefinitionOptionRelTable;
 import com.liferay.commerce.product.model.CPDefinitionOptionValueRel;
 import com.liferay.commerce.product.model.CPDefinitionOptionValueRelTable;
 import com.liferay.commerce.product.model.CPInstance;
@@ -468,6 +469,48 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 
 				return null;
 			});
+	}
+
+	@Override
+	public List<CPDefinitionOptionValueRel>
+		getApprovedCPInstanceCPDefinitionOptionValueRels(
+			long cpDefinitionOptionRelId) {
+
+		List<CPDefinitionOptionValueRel> cpDefinitionOptionValueRels =
+			cpDefinitionOptionValueRelPersistence.dslQuery(
+				DSLQueryFactoryUtil.select(
+					CPDefinitionOptionValueRelTable.INSTANCE
+				).from(
+					CPDefinitionOptionValueRelTable.INSTANCE
+				).innerJoinON(
+					CPInstanceOptionValueRelTable.INSTANCE,
+					CPInstanceOptionValueRelTable.INSTANCE.
+						CPDefinitionOptionValueRelId.eq(
+							CPDefinitionOptionValueRelTable.INSTANCE.
+								CPDefinitionOptionValueRelId)
+				).innerJoinON(
+					CPInstanceTable.INSTANCE,
+					CPInstanceTable.INSTANCE.CPInstanceId.eq(
+						CPInstanceOptionValueRelTable.INSTANCE.CPInstanceId)
+				).where(
+					CPDefinitionOptionValueRelTable.INSTANCE.
+						CPDefinitionOptionRelId.eq(
+							cpDefinitionOptionRelId
+						).and(
+							CPInstanceTable.INSTANCE.status.eq(
+								WorkflowConstants.STATUS_APPROVED)
+						)
+				).orderBy(
+					CPDefinitionOptionValueRelTable.INSTANCE.priority.ascending(),
+					CPDefinitionOptionValueRelTable.INSTANCE.createDate.ascending()
+				)
+			);
+
+		if (cpDefinitionOptionValueRels.isEmpty()) {
+			return null;
+		}
+
+		return cpDefinitionOptionValueRels;
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/test/CPDefinitionOptionValueRelLocalServiceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/test/CPDefinitionOptionValueRelLocalServiceTest.java
@@ -28,6 +28,7 @@ import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.test.util.CPTestUtil;
 import com.liferay.commerce.product.type.simple.constants.SimpleCPTypeConstants;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -50,6 +51,7 @@ import java.math.BigDecimal;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -103,6 +105,170 @@ public class CPDefinitionOptionValueRelLocalServiceTest {
 
 		_cpOptionLocalService.deleteCPOptions(_serviceContext.getCompanyId());
 		_serviceContext = null;
+	}
+
+	@Test
+	public void testGetApprovedCPInstanceCPDefinitionOptionValueRelsExcludesExpiredCPInstance()
+		throws Exception {
+
+		frutillaRule.scenario(
+			"An SKU with expirationDate in the past must not be offered as a " +
+				"selectable option value"
+		).given(
+			"A product with one SKU-contributor option and three option values"
+		).and(
+			"Three SKUs generated, one per option value, all APPROVED"
+		).when(
+			"One SKU has its expirationDate set to a past date"
+		).then(
+			"The corresponding option value is excluded from the approved list"
+		);
+
+		CPDefinitionOptionRel cpDefinitionOptionRel =
+			_buildCPDefinitionWithSKUContributorOption(3);
+
+		List<CPInstance> cpInstances =
+			_cpInstanceLocalService.getCPDefinitionInstances(
+				cpDefinitionOptionRel.getCPDefinitionId(),
+				WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		Assert.assertEquals(cpInstances.toString(), 3, cpInstances.size());
+
+		CPInstance cpInstance = cpInstances.get(0);
+
+		cpInstance.setExpirationDate(
+			new Date(System.currentTimeMillis() - 86400000L));
+
+		cpInstance = _cpInstanceLocalService.updateCPInstance(cpInstance);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED,
+			_cpInstanceLocalService.getCPInstance(
+				cpInstance.getCPInstanceId()
+			).getStatus());
+
+		List<CPDefinitionOptionValueRel> cpDefinitionOptionValueRels =
+			_cpDefinitionOptionValueRelLocalService.
+				getApprovedCPInstanceCPDefinitionOptionValueRels(
+					cpDefinitionOptionRel.getCPDefinitionOptionRelId());
+
+		Assert.assertEquals(
+			cpDefinitionOptionValueRels.toString(), 2,
+			cpDefinitionOptionValueRels.size());
+	}
+
+	@Test
+	public void testGetApprovedCPInstanceCPDefinitionOptionValueRelsExcludesNonapprovedCPInstance()
+		throws Exception {
+
+		frutillaRule.scenario(
+			"An SKU whose workflow status is not APPROVED must not be offered"
+		).given(
+			"A product with one SKU-contributor option and three option values"
+		).and(
+			"Three SKUs generated, one per option value, all APPROVED"
+		).when(
+			"One SKU is transitioned to DRAFT"
+		).then(
+			"The corresponding option value is excluded from the approved list"
+		);
+
+		CPDefinitionOptionRel cpDefinitionOptionRel =
+			_buildCPDefinitionWithSKUContributorOption(3);
+
+		List<CPInstance> cpInstances =
+			_cpInstanceLocalService.getCPDefinitionInstances(
+				cpDefinitionOptionRel.getCPDefinitionId(),
+				WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		Assert.assertEquals(cpInstances.toString(), 3, cpInstances.size());
+
+		_cpInstanceLocalService.updateStatus(
+			_serviceContext.getUserId(),
+			cpInstances.get(
+				0
+			).getCPInstanceId(),
+			WorkflowConstants.STATUS_DRAFT);
+
+		List<CPDefinitionOptionValueRel> cpDefinitionOptionValueRels =
+			_cpDefinitionOptionValueRelLocalService.
+				getApprovedCPInstanceCPDefinitionOptionValueRels(
+					cpDefinitionOptionRel.getCPDefinitionOptionRelId());
+
+		Assert.assertEquals(
+			cpDefinitionOptionValueRels.toString(), 2,
+			cpDefinitionOptionValueRels.size());
+	}
+
+	@Test
+	public void testGetApprovedCPInstanceCPDefinitionOptionValueRelsReturnsAllWhenAllApproved()
+		throws Exception {
+
+		frutillaRule.scenario(
+			"All option values with an APPROVED, non-expired SKU must be " +
+				"returned"
+		).given(
+			"A product with one SKU-contributor option and three option values"
+		).and(
+			"Three SKUs generated, one per option value, all APPROVED"
+		).then(
+			"All three option values are returned"
+		);
+
+		CPDefinitionOptionRel cpDefinitionOptionRel =
+			_buildCPDefinitionWithSKUContributorOption(3);
+
+		List<CPDefinitionOptionValueRel> cpDefinitionOptionValueRels =
+			_cpDefinitionOptionValueRelLocalService.
+				getApprovedCPInstanceCPDefinitionOptionValueRels(
+					cpDefinitionOptionRel.getCPDefinitionOptionRelId());
+
+		Assert.assertEquals(
+			cpDefinitionOptionValueRels.toString(), 3,
+			cpDefinitionOptionValueRels.size());
+	}
+
+	@Test
+	public void testGetApprovedCPInstanceCPDefinitionOptionValueRelsReturnsEmptyListWhenAllNonapproved()
+		throws Exception {
+
+		frutillaRule.scenario(
+			"If no SKU is approved and non-expired the result must be an " +
+				"empty list (not null)"
+		).given(
+			"A product with one SKU-contributor option and two option values"
+		).and(
+			"Two SKUs generated, one per option value"
+		).when(
+			"Both SKUs are transitioned to INACTIVE"
+		).then(
+			"An empty list is returned without throwing NullPointerException"
+		);
+
+		CPDefinitionOptionRel cpDefinitionOptionRel =
+			_buildCPDefinitionWithSKUContributorOption(2);
+
+		List<CPInstance> cpInstances =
+			_cpInstanceLocalService.getCPDefinitionInstances(
+				cpDefinitionOptionRel.getCPDefinitionId(),
+				WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		for (CPInstance cpInstance : cpInstances) {
+			_cpInstanceLocalService.updateStatus(
+				_serviceContext.getUserId(), cpInstance.getCPInstanceId(),
+				WorkflowConstants.STATUS_INACTIVE);
+		}
+
+		List<CPDefinitionOptionValueRel> cpDefinitionOptionValueRels =
+			_cpDefinitionOptionValueRelLocalService.
+				getApprovedCPInstanceCPDefinitionOptionValueRels(
+					cpDefinitionOptionRel.getCPDefinitionOptionRelId());
+
+		Assert.assertNotNull(cpDefinitionOptionValueRels);
+		Assert.assertTrue(cpDefinitionOptionValueRels.isEmpty());
 	}
 
 	@Test
@@ -1273,6 +1439,27 @@ public class CPDefinitionOptionValueRelLocalServiceTest {
 			newCPDefinitionOptionValueRel, cpInstance.getCPInstanceId(),
 			newCPDefinitionOptionValueRel.isPreselected(), price,
 			cpDefinitionOptionValueRel.getQuantity());
+	}
+
+	private CPDefinitionOptionRel _buildCPDefinitionWithSKUContributorOption(
+			int optionValuesCount)
+		throws Exception {
+
+		CPDefinition cpDefinition = CPTestUtil.addCPDefinitionFromCatalog(
+			_commerceCatalog.getGroupId(), SimpleCPTypeConstants.NAME, true,
+			true);
+
+		List<CPDefinitionOptionRel> cpDefinitionOptionRels =
+			CPTestUtil.addCPOption(
+				_commerceCatalog.getGroupId(), cpDefinition.getCPDefinitionId(),
+				1, optionValuesCount);
+
+		_cpDefinitionOptionRels.addAll(cpDefinitionOptionRels);
+
+		_cpInstanceLocalService.buildCPInstances(
+			cpDefinition.getCPDefinitionId(), _serviceContext);
+
+		return cpDefinitionOptionRels.get(0);
 	}
 
 	private CPInstance _getCPInstance(long cpDefinitionId) throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ProductOptionDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ProductOptionDTOConverter.java
@@ -7,8 +7,13 @@ package com.liferay.headless.commerce.delivery.catalog.internal.dto.v1_0.convert
 
 import com.liferay.commerce.product.model.CPDefinitionOptionRel;
 import com.liferay.commerce.product.model.CPDefinitionOptionValueRel;
+import com.liferay.commerce.product.model.CPInstance;
+import com.liferay.commerce.product.model.CPInstanceOptionValueRel;
 import com.liferay.commerce.product.model.CPOption;
 import com.liferay.commerce.product.service.CPDefinitionOptionRelLocalService;
+import com.liferay.commerce.product.service.CPDefinitionOptionValueRelLocalService;
+import com.liferay.commerce.product.service.CPInstanceLocalService;
+import com.liferay.commerce.product.service.CPInstanceOptionValueRelLocalService;
 import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.ProductOption;
 import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.ProductOptionValue;
 import com.liferay.headless.commerce.delivery.catalog.internal.dto.v1_0.converter.constants.DTOConverterConstants;
@@ -78,10 +83,38 @@ public class ProductOptionDTOConverter
 			DTOConverterContext dtoConverterContext)
 		throws Exception {
 
+		List<CPDefinitionOptionValueRel> cpDefinitionOptionValueRels =
+			new ArrayList<>();
 		List<ProductOptionValue> productOptionValues = new ArrayList<>();
 
+		if (cpDefinitionOptionRel.isSkuContributor()) {
+			List<CPInstanceOptionValueRel> cpInstanceOptionValueRels =
+				_cpInstanceOptionValueRelLocalService.
+					getCPDefinitionOptionRelCPInstanceOptionValueRels(
+						cpDefinitionOptionRel.getCPDefinitionOptionRelId());
+
+			for (CPInstanceOptionValueRel cpInstanceOptionValueRel :
+					cpInstanceOptionValueRels) {
+
+				CPInstance cpInstance = _cpInstanceLocalService.getCPInstance(
+					cpInstanceOptionValueRel.getCPInstanceId());
+
+				if (cpInstance.isApproved()) {
+					cpDefinitionOptionValueRels.add(
+						_cpDefinitionOptionValueRelLocalService.
+							getCPDefinitionOptionValueRel(
+								cpInstanceOptionValueRel.
+									getCPDefinitionOptionValueRelId()));
+				}
+			}
+		}
+		else {
+			cpDefinitionOptionValueRels =
+				cpDefinitionOptionRel.getCPDefinitionOptionValueRels();
+		}
+
 		for (CPDefinitionOptionValueRel cpDefinitionOptionValueRel :
-				cpDefinitionOptionRel.getCPDefinitionOptionValueRels()) {
+				cpDefinitionOptionValueRels) {
 
 			if (cpDefinitionOptionValueRel.getCPDefinitionOptionRelId() == 0) {
 				cpDefinitionOptionValueRel.setCPDefinitionOptionRelId(
@@ -114,6 +147,17 @@ public class ProductOptionDTOConverter
 	@Reference
 	private CPDefinitionOptionRelLocalService
 		_cpDefinitionOptionRelLocalService;
+
+	@Reference
+	private CPDefinitionOptionValueRelLocalService
+		_cpDefinitionOptionValueRelLocalService;
+
+	@Reference
+	private CPInstanceLocalService _cpInstanceLocalService;
+
+	@Reference
+	private CPInstanceOptionValueRelLocalService
+		_cpInstanceOptionValueRelLocalService;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ProductOptionDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/converter/ProductOptionDTOConverter.java
@@ -7,13 +7,9 @@ package com.liferay.headless.commerce.delivery.catalog.internal.dto.v1_0.convert
 
 import com.liferay.commerce.product.model.CPDefinitionOptionRel;
 import com.liferay.commerce.product.model.CPDefinitionOptionValueRel;
-import com.liferay.commerce.product.model.CPInstance;
-import com.liferay.commerce.product.model.CPInstanceOptionValueRel;
 import com.liferay.commerce.product.model.CPOption;
 import com.liferay.commerce.product.service.CPDefinitionOptionRelLocalService;
 import com.liferay.commerce.product.service.CPDefinitionOptionValueRelLocalService;
-import com.liferay.commerce.product.service.CPInstanceLocalService;
-import com.liferay.commerce.product.service.CPInstanceOptionValueRelLocalService;
 import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.ProductOption;
 import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.ProductOptionValue;
 import com.liferay.headless.commerce.delivery.catalog.internal.dto.v1_0.converter.constants.DTOConverterConstants;
@@ -83,30 +79,14 @@ public class ProductOptionDTOConverter
 			DTOConverterContext dtoConverterContext)
 		throws Exception {
 
-		List<CPDefinitionOptionValueRel> cpDefinitionOptionValueRels =
-			new ArrayList<>();
+		List<CPDefinitionOptionValueRel> cpDefinitionOptionValueRels;
 		List<ProductOptionValue> productOptionValues = new ArrayList<>();
 
 		if (cpDefinitionOptionRel.isSkuContributor()) {
-			List<CPInstanceOptionValueRel> cpInstanceOptionValueRels =
-				_cpInstanceOptionValueRelLocalService.
-					getCPDefinitionOptionRelCPInstanceOptionValueRels(
+			cpDefinitionOptionValueRels =
+				_cpDefinitionOptionValueRelLocalService.
+					getApprovedCPInstanceCPDefinitionOptionValueRels(
 						cpDefinitionOptionRel.getCPDefinitionOptionRelId());
-
-			for (CPInstanceOptionValueRel cpInstanceOptionValueRel :
-					cpInstanceOptionValueRels) {
-
-				CPInstance cpInstance = _cpInstanceLocalService.getCPInstance(
-					cpInstanceOptionValueRel.getCPInstanceId());
-
-				if (cpInstance.isApproved()) {
-					cpDefinitionOptionValueRels.add(
-						_cpDefinitionOptionValueRelLocalService.
-							getCPDefinitionOptionValueRel(
-								cpInstanceOptionValueRel.
-									getCPDefinitionOptionValueRelId()));
-				}
-			}
 		}
 		else {
 			cpDefinitionOptionValueRels =
@@ -151,13 +131,6 @@ public class ProductOptionDTOConverter
 	@Reference
 	private CPDefinitionOptionValueRelLocalService
 		_cpDefinitionOptionValueRelLocalService;
-
-	@Reference
-	private CPInstanceLocalService _cpInstanceLocalService;
-
-	@Reference
-	private CPInstanceOptionValueRelLocalService
-		_cpInstanceOptionValueRelLocalService;
 
 	@Reference
 	private Language _language;

--- a/modules/test/playwright/helpers/HeadlessCommerceAdminCatalogApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessCommerceAdminCatalogApiHelper.ts
@@ -189,6 +189,7 @@ type TRelatedProduct = {
 type TSku = {
 	cost: number;
 	discontinued?: boolean;
+	expirationDate?: string;
 	gtin?: string;
 	id?: number;
 	manufacturerPartNumber?: string;
@@ -481,7 +482,7 @@ export class HeadlessCommerceAdminCatalogApiHelper {
 		);
 	}
 
-	async patchSku(cpInstanceId: string, sku?: TSku) {
+	async patchSku(cpInstanceId: string, sku?: Partial<TSku>) {
 		return this.apiHelpers.patch(
 			`${this.apiHelpers.baseUrl}${this.basePath}/skus/${cpInstanceId}`,
 			{sku: 'Sku' + getRandomInt(), ...(sku || {})}

--- a/modules/test/playwright/pages/commerce/commerce-product-definitions-web/commerceAdminProductDetailsSkusPage.ts
+++ b/modules/test/playwright/pages/commerce/commerce-product-definitions-web/commerceAdminProductDetailsSkusPage.ts
@@ -20,6 +20,7 @@ export class CommerceAdminProductDetailsSkusPage extends CommerceDNDTablePage {
 		strictEqual?: boolean
 	) => Promise<{column: Locator; row: Locator}>;
 	readonly inventoryTableRowAction: (pageName: string) => Promise<Locator>;
+	readonly neverExpireCheckbox: Locator;
 	readonly page: Page;
 	readonly pricinQuantity: Locator;
 	readonly sidePanelDetailsSkuFieldName: Locator;
@@ -29,8 +30,9 @@ export class CommerceAdminProductDetailsSkusPage extends CommerceDNDTablePage {
 	readonly sidePanelNestedFrame: FrameLocator;
 	readonly sidePanelNestedPriceListPrice: Locator;
 	readonly sidePanelNestedSaveButton: Locator;
-	readonly sidePanelSkuInventoryQuantity: Locator;
+	readonly sidePanelSaveAsDraftButton: Locator;
 	readonly sidePanelSaveButton: Locator;
+	readonly sidePanelSkuInventoryQuantity: Locator;
 	readonly sidePanelSkuPriceTableRowLink: (priceListName: string) => Locator;
 	readonly skuAddButton: Locator;
 	readonly skuAddModal: FrameLocator;
@@ -120,6 +122,8 @@ export class CommerceAdminProductDetailsSkusPage extends CommerceDNDTablePage {
 				`Cannot locate table row with name ${warehouseName}`
 			);
 		};
+		this.neverExpireCheckbox =
+			this.sidePanelFrame.getByLabel('Never Expire');
 		this.page = page;
 		this.pricinQuantity = page
 			.frameLocator('iframe')
@@ -142,6 +146,10 @@ export class CommerceAdminProductDetailsSkusPage extends CommerceDNDTablePage {
 		this.sidePanelNestedSaveButton = this.sidePanelNestedFrame.getByRole(
 			'button',
 			{exact: true, name: 'Save'}
+		);
+		this.sidePanelSaveAsDraftButton = this.sidePanelFrame.getByRole(
+			'button',
+			{exact: true, name: 'Save as Draft'}
 		);
 		this.sidePanelSaveButton = this.sidePanelFrame.getByRole('button', {
 			exact: true,

--- a/modules/test/playwright/pages/commerce/commerce-product-definitions-web/commerceAdminProductDetailsSkusPage.ts
+++ b/modules/test/playwright/pages/commerce/commerce-product-definitions-web/commerceAdminProductDetailsSkusPage.ts
@@ -20,7 +20,6 @@ export class CommerceAdminProductDetailsSkusPage extends CommerceDNDTablePage {
 		strictEqual?: boolean
 	) => Promise<{column: Locator; row: Locator}>;
 	readonly inventoryTableRowAction: (pageName: string) => Promise<Locator>;
-	readonly neverExpireCheckbox: Locator;
 	readonly page: Page;
 	readonly pricinQuantity: Locator;
 	readonly sidePanelDetailsSkuFieldName: Locator;
@@ -30,7 +29,6 @@ export class CommerceAdminProductDetailsSkusPage extends CommerceDNDTablePage {
 	readonly sidePanelNestedFrame: FrameLocator;
 	readonly sidePanelNestedPriceListPrice: Locator;
 	readonly sidePanelNestedSaveButton: Locator;
-	readonly sidePanelSaveAsDraftButton: Locator;
 	readonly sidePanelSaveButton: Locator;
 	readonly sidePanelSkuInventoryQuantity: Locator;
 	readonly sidePanelSkuPriceTableRowLink: (priceListName: string) => Locator;
@@ -122,8 +120,6 @@ export class CommerceAdminProductDetailsSkusPage extends CommerceDNDTablePage {
 				`Cannot locate table row with name ${warehouseName}`
 			);
 		};
-		this.neverExpireCheckbox =
-			this.sidePanelFrame.getByLabel('Never Expire');
 		this.page = page;
 		this.pricinQuantity = page
 			.frameLocator('iframe')
@@ -146,10 +142,6 @@ export class CommerceAdminProductDetailsSkusPage extends CommerceDNDTablePage {
 		this.sidePanelNestedSaveButton = this.sidePanelNestedFrame.getByRole(
 			'button',
 			{exact: true, name: 'Save'}
-		);
-		this.sidePanelSaveAsDraftButton = this.sidePanelFrame.getByRole(
-			'button',
-			{exact: true, name: 'Save as Draft'}
 		);
 		this.sidePanelSaveButton = this.sidePanelFrame.getByRole('button', {
 			exact: true,

--- a/modules/test/playwright/tests/commerce/commerce-product-content-web/main/productDetails.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-content-web/main/productDetails.spec.ts
@@ -1368,7 +1368,6 @@ test(
 	{tag: '@LPD-85260'},
 	async ({
 		apiHelpers,
-		commerceAdminProductDetailsSkusPage,
 		commerceAdminProductPage,
 		page,
 		productDetailsPage,
@@ -1461,12 +1460,12 @@ test(
 			page.getByText('Showing 1 to 3 of 3 entries.')
 		).toBeVisible();
 
-		await commerceAdminProductDetailsSkusPage
-			.skusTableRowLink('BLACK')
-			.click();
+		const blackSku =
+			await apiHelpers.headlessCommerceAdminCatalog.getSkuByName('BLACK');
 
-		await commerceAdminProductDetailsSkusPage.neverExpireCheckbox.uncheck();
-		await commerceAdminProductDetailsSkusPage.sidePanelSaveAsDraftButton.click();
+		await apiHelpers.headlessCommerceAdminCatalog.patchSku(blackSku.id, {
+			expirationDate: '2020-01-01T00:00:00Z',
+		});
 
 		await page.goto(`/web/${site.name}/p/${product.name['en_US']}`, {
 			waitUntil: 'networkidle',

--- a/modules/test/playwright/tests/commerce/commerce-product-content-web/main/productDetails.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-content-web/main/productDetails.spec.ts
@@ -1362,3 +1362,128 @@ test(
 		}
 	}
 );
+
+test(
+	'User cannot see expired SKUs',
+	{tag: '@LPD-85260'},
+	async ({
+		apiHelpers,
+		commerceAdminProductDetailsSkusPage,
+		commerceAdminProductPage,
+		page,
+		productDetailsPage,
+		site,
+		widgetPagePage,
+	}) => {
+		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
+			groupId: site.id,
+			title: getRandomString(),
+		});
+
+		await apiHelpers.headlessCommerceAdminChannel.postChannel({
+			siteGroupId: site.id,
+		});
+
+		const catalog =
+			await apiHelpers.headlessCommerceAdminCatalog.postCatalog({
+				name: 'Catalog',
+			});
+		const option = await apiHelpers.headlessCommerceAdminCatalog.postOption(
+			'select',
+			'color',
+			'Color',
+			1
+		);
+		const product =
+			await apiHelpers.headlessCommerceAdminCatalog.postProduct({
+				catalogId: catalog.id,
+				name: {en_US: getRandomString()},
+				productOptions: [
+					{
+						fieldType: 'select',
+						key: 'color',
+						name: {
+							en_US: 'Color',
+						},
+						optionId: option.id,
+						priority: 1,
+						productOptionValues: [
+							{
+								key: 'black',
+								name: {
+									en_US: 'Black',
+								},
+								priority: 0,
+							},
+							{
+								key: 'white',
+								name: {
+									en_US: 'White',
+								},
+								priority: 1,
+							},
+						],
+						skuContributor: true,
+					},
+				],
+			});
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyURL}`);
+
+		await widgetPagePage.addPortlet('Product Details');
+
+		await page.goto(`/web/${site.name}/p/${product.name['en_US']}`, {
+			waitUntil: 'networkidle',
+		});
+
+		await expect(
+			await productDetailsPage.optionSelector('Color')
+		).toBeVisible();
+
+		await productDetailsPage.optionSelector('Color').click();
+
+		let optionSelectorOptionValues = await productDetailsPage
+			.optionSelector('Color')
+			.locator('option')
+			.allTextContents();
+
+		expect(optionSelectorOptionValues).toEqual([
+			'Choose an Option',
+			'Black',
+			'White',
+		]);
+
+		await commerceAdminProductPage.gotoProduct(product.name['en_US']);
+
+		await commerceAdminProductPage.generateSkus();
+
+		await expect(
+			page.getByText('Showing 1 to 3 of 3 entries.')
+		).toBeVisible();
+
+		await commerceAdminProductDetailsSkusPage
+			.skusTableRowLink('BLACK')
+			.click();
+
+		await commerceAdminProductDetailsSkusPage.neverExpireCheckbox.uncheck();
+		await commerceAdminProductDetailsSkusPage.sidePanelSaveAsDraftButton.click();
+
+		await page.goto(`/web/${site.name}/p/${product.name['en_US']}`, {
+			waitUntil: 'networkidle',
+		});
+
+		await expect(
+			await productDetailsPage.optionSelector('Color')
+		).toBeVisible();
+
+		optionSelectorOptionValues = await productDetailsPage
+			.optionSelector('Color')
+			.locator('option')
+			.allTextContents();
+
+		expect(optionSelectorOptionValues).toEqual([
+			'Choose an Option',
+			'White',
+		]);
+	}
+);


### PR DESCRIPTION
Hi @gianmarcobrunialti,

https://liferay.atlassian.net/browse/LPD-85260, tied to LPP.

Fix alters existing logic when converting the DTO where we check if a matching CPinstance exists for a given SKU/JSONArray. I've specifically hinged it on a new parameter as to not interfere in cases where we do want to see the expired options, but please let me know if that should be changed. A playwright test is also included. Thanks!