### PR TITLE
LPD-85346 Adapting classes to backport upgradeProcess

### DIFF
--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/upgrade/registry/CommerceProductServiceUpgradeStepRegistrator.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/upgrade/registry/CommerceProductServiceUpgradeStepRegistrator.java
@@ -651,13 +651,15 @@ public class CommerceProductServiceUpgradeStepRegistrator
 
 		registry.register("5.27.0", "5.27.1", new DummyUpgradeStep());
 
+		registry.register("5.27.1", "5.27.2", new DummyUpgradeStep());
+
 		registry.register(
-			"5.27.1", "5.27.2",
-			new com.liferay.commerce.product.internal.upgrade.v5_27_2.
+			"5.27.2", "5.27.3",
+			new com.liferay.commerce.product.internal.upgrade.v5_27_3.
 				CPDefinitionSpecificationOptionValueUpgradeProcess());
 
 		registry.register(
-			"5.27.2", "5.28.0",
+			"5.27.3", "5.28.0",
 			new com.liferay.commerce.product.internal.upgrade.v5_28_0.
 				CPSpecificationOptionUpgradeProcess());
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/upgrade/v5_27_3/CPDefinitionSpecificationOptionValueUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/upgrade/v5_27_3/CPDefinitionSpecificationOptionValueUpgradeProcess.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.commerce.product.internal.upgrade.v5_27_2;
+package com.liferay.commerce.product.internal.upgrade.v5_27_3;
 
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/internal/upgrade/v5_27_3/test/CPDefinitionSpecificationOptionValueUpgradeProcessTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/internal/upgrade/v5_27_3/test/CPDefinitionSpecificationOptionValueUpgradeProcessTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.commerce.product.internal.upgrade.v5_27_2.test;
+package com.liferay.commerce.product.internal.upgrade.v5_27_3.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.commerce.product.model.CPDefinition;
@@ -124,7 +124,7 @@ public class CPDefinitionSpecificationOptionValueUpgradeProcessTest {
 	}
 
 	private static final String _CLASS_NAME =
-		"com.liferay.commerce.product.internal.upgrade.v5_27_2." +
+		"com.liferay.commerce.product.internal.upgrade.v5_27_3." +
 			"CPDefinitionSpecificationOptionValueUpgradeProcess";
 
 	@Inject


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85346

cc @smottal

change the class

[CommerceProductServiceUpgradeStepRegistrator.java](https://github.com/liferay/liferay-portal/blob/master/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/upgrade/registry/CommerceProductServiceUpgradeStepRegistrator.java)


AS IS



		registry.register("5.27.0", "5.27.1", new DummyUpgradeStep());

		registry.register(
			"5.27.1", "5.27.2",
			new com.liferay.commerce.product.internal.upgrade.v5_27_2.
				CPDefinitionSpecificationOptionValueUpgradeProcess());

		registry.register(
			"5.27.2", "5.28.0",
			new com.liferay.commerce.product.internal.upgrade.v5_28_0.
				CPSpecificationOptionUpgradeProcess());

TO BE




		registry.register("5.27.0", "5.27.1", new DummyUpgradeStep());

		registry.register("5.27.1", "5.27.2", new DummyUpgradeStep());

		registry.register(
			"5.27.2", "5.27.3",
			new com.liferay.commerce.product.internal.upgrade.v5_27_3.
				CPDefinitionSpecificationOptionValueUpgradeProcess());

		registry.register(
			"5.27.3", "5.28.0",
			new com.liferay.commerce.product.internal.upgrade.v5_28_0.
				CPSpecificationOptionUpgradeProcess());

in order to backport the bug [LPD-78239: Insecure Direct Object Reference vulnerability in Tax Categories
Closed](https://liferay.atlassian.net/browse/LPD-78239)
 