### PR TITLE
LPD-83788 Fix color contrast and accessibility for Export/Import revamp

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/FieldCheckbox.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/FieldCheckbox.tsx
@@ -23,6 +23,8 @@ export function FieldCheckbox({
 	name: string;
 	onChange: (checked: boolean) => void;
 } & React.ComponentProps<typeof ClayCheckbox>) {
+	const {disabled} = restProps;
+
 	const fieldId = id ?? name;
 	const labelId = `${fieldId}-label`;
 	const descriptionId = `${fieldId}-description`;
@@ -35,9 +37,18 @@ export function FieldCheckbox({
 
 	return (
 		<div
-			className="border mb-2 p-3 rounded text-3"
+			aria-checked={checked}
+			className="border mb-2 p-3 rounded text-secondary"
 			onClick={handleChange}
+			onKeyDown={(event) => {
+				if (event.key === ' ') {
+					event.preventDefault();
+					handleChange();
+				}
+			}}
+			role="checkbox"
 			style={{cursor: 'pointer'}}
+			tabIndex={disabled ? -1 : 0}
 		>
 			<ClayLayout.ContentRow padded>
 				<ClayLayout.ContentCol expand={false}>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikDebug.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikDebug.tsx
@@ -19,7 +19,7 @@ export function FormikDebug() {
 					validationSchema: _validationSchema,
 					...rest
 				}) => (
-					<pre className="p-2 text-3">
+					<pre className="p-2 text-secondary">
 						{JSON.stringify(rest, null, 2)}
 					</pre>
 				)}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/steps/SetupStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/steps/SetupStep.tsx
@@ -25,7 +25,7 @@ export default function SetupStep() {
 						)}
 					</div>
 
-					<div className="sheet-text text-3">
+					<div className="sheet-text text-secondary">
 						{Liferay.Language.get(
 							'provide-a-descriptive-name-for-your-export'
 						)}
@@ -49,7 +49,7 @@ export default function SetupStep() {
 					</div>
 
 					<div
-						className="sheet-text text-3"
+						className="sheet-text text-secondary"
 						id="selectedSectionIds-description"
 					>
 						{Liferay.Language.get(


### PR DESCRIPTION
LPD-83788 Fix color contrast and accessibility for Export/Import revamp.

1. Updated FieldCheckbox.tsx: Changed the text-3 class to text-secondary to ensure the minimum color contrast ratio of 4.5:1 is met for the text. Also improved keyboard accessibility by adding role="checkbox", aria-checked, tabIndex, and onKeyDown handler.
2. Updated SetupStep.tsx: Updated helper text classes from text-3 to text-secondary for better accessibility and readability.
3. Updated FormikDebug.tsx: Changed the text-3 class to text-secondary in the debug component's pre element.

Jira Ticket: https://liferay.atlassian.net/browse/LPD-83788