### PR TITLE
LPD-85262 Fix accessibility test caused by the Maintenance label

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
@@ -79,6 +79,8 @@ export default function FeatureIndicator({
 		tooltipTitle = Liferay.Language.get('open-maintenance-mode-definition');
 	}
 
+	const isTranslucent = type === 'beta';
+
 	return (
 		<LearnResourcesContext.Provider value={learnResourceContext}>
 			{interactive ? (
@@ -102,7 +104,7 @@ export default function FeatureIndicator({
 								rounded
 								size="xs"
 								title={tooltipTitle}
-								translucent
+								translucent={isTranslucent}
 							>
 								<span className="inline-item text-uppercase">
 									{label}
@@ -130,7 +132,7 @@ export default function FeatureIndicator({
 					dark={dark}
 					displayType={displayType}
 					label={label}
-					translucent
+					translucent={isTranslucent}
 				/>
 			)}
 		</LearnResourcesContext.Provider>


### PR DESCRIPTION
LPD-85262 Fix accessibility test caused by the Maintenance label.

1. Updated FeatureIndicator.tsx: Set the translucent property to be enabled only for the beta type. This ensures that maintenance and deprecated labels meet the minimum color contrast ratio thresholds by rendering them as solid elements.

Jira Ticket: https://liferay.atlassian.net/browse/LPD-85262