### PR TITLE
LPD-46232 Fix double escaping for product localization fields in commerce admin

### DIFF
--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/persistence/impl/CPDefinitionLocalizationPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/persistence/impl/CPDefinitionLocalizationPersistenceImpl.java
@@ -1149,46 +1149,6 @@ public class CPDefinitionLocalizationPersistenceImpl
 						cpDefinitionLocalizationId, ContentTypes.TEXT_HTML,
 						Sanitizer.MODE_ALL,
 						cpDefinitionLocalization.getDescription(), null));
-
-				cpDefinitionLocalization.setMetaDescription(
-					SanitizerUtil.sanitize(
-						companyId, groupId, userId,
-						CPDefinitionLocalization.class.getName(),
-						cpDefinitionLocalizationId, ContentTypes.TEXT_HTML,
-						Sanitizer.MODE_ALL,
-						cpDefinitionLocalization.getMetaDescription(), null));
-
-				cpDefinitionLocalization.setMetaKeywords(
-					SanitizerUtil.sanitize(
-						companyId, groupId, userId,
-						CPDefinitionLocalization.class.getName(),
-						cpDefinitionLocalizationId, ContentTypes.TEXT_HTML,
-						Sanitizer.MODE_ALL,
-						cpDefinitionLocalization.getMetaKeywords(), null));
-
-				cpDefinitionLocalization.setMetaTitle(
-					SanitizerUtil.sanitize(
-						companyId, groupId, userId,
-						CPDefinitionLocalization.class.getName(),
-						cpDefinitionLocalizationId, ContentTypes.TEXT_HTML,
-						Sanitizer.MODE_ALL,
-						cpDefinitionLocalization.getMetaTitle(), null));
-
-				cpDefinitionLocalization.setName(
-					SanitizerUtil.sanitize(
-						companyId, groupId, userId,
-						CPDefinitionLocalization.class.getName(),
-						cpDefinitionLocalizationId, ContentTypes.TEXT_PLAIN,
-						Sanitizer.MODE_ALL, cpDefinitionLocalization.getName(),
-						null));
-
-				cpDefinitionLocalization.setShortDescription(
-					SanitizerUtil.sanitize(
-						companyId, groupId, userId,
-						CPDefinitionLocalization.class.getName(),
-						cpDefinitionLocalizationId, ContentTypes.TEXT_HTML,
-						Sanitizer.MODE_ALL,
-						cpDefinitionLocalization.getShortDescription(), null));
 			}
 			catch (SanitizerException sanitizerException) {
 				throw new SystemException(sanitizerException);

--- a/modules/apps/commerce/commerce-product-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/commerce/commerce-product-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -305,23 +305,18 @@
 		</field>
 		<field name="metaDescription" type="String">
 			<hint name="max-length">255</hint>
-			<sanitize content-type="text/html" modes="ALL" />
 		</field>
 		<field name="metaKeywords" type="String">
 			<hint name="max-length">255</hint>
-			<sanitize content-type="text/html" modes="ALL" />
 		</field>
 		<field name="metaTitle" type="String">
 			<hint name="max-length">255</hint>
-			<sanitize content-type="text/html" modes="ALL" />
 		</field>
 		<field name="name" type="String">
 			<hint-collection name="TEXTAREA" />
-			<sanitize content-type="text/plain" modes="ALL" />
 		</field>
 		<field name="shortDescription" type="String">
 			<hint-collection name="TEXTAREA" />
-			<sanitize content-type="text/html" modes="ALL" />
 		</field>
 	</model>
 	<model name="com.liferay.commerce.product.model.CPDefinitionOptionRel">


### PR DESCRIPTION
This PR fixes the double escaping of product localization fields (name, short description, and SEO fields) in the commerce admin (LPD-46232).

The following changes were made:
- Removed the `sanitize` hint for the `name`, `shortDescription`, `metaTitle`, `metaDescription`, and `metaKeywords` fields in `CPDefinitionLocalization` within `portlet-model-hints.xml`.
- Updated `CPDefinitionLocalizationPersistenceImpl.java` to stop pre-escaping these fields at the persistence layer.
- Ensured that these fields are stored in their raw form, allowing the UI-level escaping (e.g., in `header/page.jsp` and `aui:input` tags) to work correctly without double-encoding.

Jira Ticket: https://liferay.atlassian.net/browse/LPD-46232