### PR TITLE
LPD-65755 Only update unique categories

### DIFF
--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CPDefinitionsImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CPDefinitionsImporter.java
@@ -87,9 +87,11 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -398,12 +400,16 @@ public class CPDefinitionsImporter {
 					cpDefinition.getModelClassName(),
 					cpDefinition.getCPDefinitionId());
 
-			assetCategories.addAll(cpDefinitionAssetCategories);
+			Set<AssetCategory> mergedAssetCategories = new HashSet<>(
+				assetCategories);
+
+			mergedAssetCategories.addAll(cpDefinitionAssetCategories);
 
 			cpDefinition = _updateCPDefinition(
 				cpDefinition,
 				ListUtil.toLongArray(
-					assetCategories, AssetCategory.CATEGORY_ID_ACCESSOR),
+					new ArrayList<>(mergedAssetCategories),
+					AssetCategory.CATEGORY_ID_ACCESSOR),
 				serviceContext);
 
 			Indexer<CPDefinition> indexer =

--- a/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/object-relationships/user-experience-relationship.json
+++ b/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/object-relationships/user-experience-relationship.json
@@ -1,5 +1,6 @@
 {
 	"deletionType": "cascade",
+	"externalReferenceCode": "USER_TO_USER_EXPERIENCE",
 	"label": {
 		"en_US": "User to User Experience"
 	},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-65755

Hey team, this is a fix for a flaky playwright test. The clarity site initializer fails to be created twice since there is a unique-constraint violation when the existing CPDefinition tries to import the same JSON-defined categories.

cc @smottal