### PR TITLE
LPD-86900 Fix flaky ProductConfigurationListResourceTest

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/ProductConfigurationListResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/ProductConfigurationListResourceTest.java
@@ -17,7 +17,10 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.Inject;
+
+import java.util.Date;
 
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -45,6 +48,13 @@ public class ProductConfigurationListResourceTest
 		_masterCPConfigurationList =
 			_cpConfigurationListLocalService.getMasterCPConfigurationList(
 				_commerceCatalog.getGroupId());
+
+		_masterCPConfigurationList.setCreateDate(
+			new Date(System.currentTimeMillis() - Time.MONTH));
+
+		_masterCPConfigurationList =
+			_cpConfigurationListLocalService.updateCPConfigurationList(
+				_masterCPConfigurationList);
 	}
 
 	@Override


### PR DESCRIPTION
The `testGetProductConfigurationListsPageWithFilterDateTimeEquals` test fails with "expected:<1> but was:<2>" because setUp() creates a CommerceCatalog, which auto-creates a master CPConfigurationList in the same group.
The test body then POSTs a second CPConfigurationList only milliseconds later. The base test applies a "between" filter on createDate with a ±2 second window and expects exactly 1 result, but both the master (from setUp) and the test entity fall inside that window, so the listing returns 2 entries.

ServiceBuilder always sets createDate to "now" on insert and the resource impl does not propagate the user-supplied value, so the collision cannot be avoided through the DTO.

Fix: in setUp(), after retrieving the auto-created master, push its createDate one month into the past and persist via updateCPConfigurationList. The service method is annotated with `@Indexable(REINDEX)`, so the search index reflects the new date and the ±2 second window no longer captures the master.

cc @smottal 