### PR TITLE
LPD-87874 Fix locator in commerceAdminShipmentWorkflow.spec.ts

### DIFF
--- a/modules/test/playwright/pages/commerce/commerce-shipment-web/commerceAdminShipmentsPage.ts
+++ b/modules/test/playwright/pages/commerce/commerce-shipment-web/commerceAdminShipmentsPage.ts
@@ -66,9 +66,9 @@ export class CommerceAdminShipmentsPage extends CommerceIframeDNDTablePage {
 		this.editProductFrame = page.frameLocator('iframe');
 		this.addQuantityInShipment =
 			this.editProductFrame.getByRole('spinbutton');
-		this.addProductsToShipment = page.getByText(
-			'Add Products to This Shipment'
-		);
+		this.addProductsToShipment = page
+			.getByTestId('managementToolbar')
+			.locator('[data-testid="fdsCreationActionButton"]');
 		this.globalMenuPage = new GlobalMenuPage(page);
 		this.carrierDetailsEditLink = page
 			.getByText('Carrier Details Edit')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87874

 Cause:
  The `addProductsToShipment` locator was resolved by visible text
  (`page.getByText('Add Products to This Shipment')`). That label is no
  longer unique on the shipment admin page (it also appears outside the
  FDS management toolbar, e.g. in section headings/empty states), so
  Playwright's strict mode matched multiple elements and the click failed
  intermittently across the specs that use it
  (commerceAdminShipmentWorkflow, skuUnitOfMeasure, checkout,
  commerceAdminOrderDetails).

  Fix:
  Scope the locator to the FDS management toolbar and target the standard
  creation action button via its `data-testid`:

      page
          .getByTestId('managementToolbar')
          .locator('[data-testid="fdsCreationActionButton"]');

  This aligns with the FDS toolbar conventions already used elsewhere in
  the page object, is independent of the button label/translation, and
  yields a single deterministic match.
  
  cc @smottal 