### PR TITLE
LPD-84651 Fix localization of CMS pages tree and structure labels

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/getLocalizedValue.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/getLocalizedValue.ts
@@ -5,7 +5,7 @@
 
 export default function getLocalizedValue(
 	value: Liferay.Language.LocalizedValue<string>,
-	languageId = Liferay.ThemeDisplay.getDefaultLanguageId()
+	languageId = Liferay.ThemeDisplay.getLanguageId()
 ) {
-	return value[languageId] || '';
+	return (value && (value[languageId] || value[Liferay.ThemeDisplay.getDefaultLanguageId()])) || '';
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/find_and_replace/utils/enrichItem.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/find_and_replace/utils/enrichItem.ts
@@ -5,6 +5,7 @@
 
 import {ISearchAssetObjectEntry} from '../../../common/types/AssetType';
 import {StickerConfig} from '../../../common/types/StickerConfig';
+import getLocalizedValue from '../../../common/utils/getLocalizedValue';
 import {getFileMimeTypeObjectDefinitionStickerValue} from '../../props_transformer/utils/transformViewsItemProps';
 import {ReplaceItem} from '../contexts/FindAndReplaceContext';
 
@@ -49,7 +50,7 @@ export function enrichItem({
 function getTitle(item: ReplaceItem) {
 	const field = item.fields.find((field) => field.name === 'title');
 
-	return field?.value_i18n![
-		Liferay.ThemeDisplay.getDefaultLanguageId()
-	] as string;
+	return getLocalizedValue(
+		field?.value_i18n as Liferay.Language.LocalizedValue<string>
+	);
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/AddChildDropdown.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/AddChildDropdown.tsx
@@ -60,6 +60,8 @@ export default function AddChildDropdown({
 				label: {
 					[Liferay.ThemeDisplay.getDefaultLanguageId()]:
 						Liferay.Language.get('select-related-content'),
+					[Liferay.ThemeDisplay.getLanguageId()]:
+						Liferay.Language.get('select-related-content'),
 				},
 				multiselection: false,
 				name: getRandomName(),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/LocalizedInput.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/LocalizedInput.tsx
@@ -38,7 +38,7 @@ export function LocalizedInput({
 		useState<Translations>(initialTranslations);
 
 	const [locale, setLocale] = useState(
-		Liferay.ThemeDisplay.getDefaultLanguageId()
+		Liferay.ThemeDisplay.getLanguageId()
 	);
 
 	useEffect(() => {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/picklist_builder/AddOptionModal.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/picklist_builder/AddOptionModal.tsx
@@ -21,6 +21,8 @@ import Input from '../Input';
 const DEFAULT_NAME = {
 	[Liferay.ThemeDisplay.getDefaultLanguageId()]:
 		Liferay.Language.get('option'),
+	[Liferay.ThemeDisplay.getLanguageId()]:
+		Liferay.Language.get('option'),
 };
 
 export default function AddOptionModal({

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext.tsx
@@ -591,8 +591,8 @@ function reducer(state: State, action: Action): State {
 			const {name, uuid} = action;
 			const {structure} = state;
 
-			const defaultLanguageId =
-				Liferay.ThemeDisplay.getDefaultLanguageId();
+			const languageId =
+				Liferay.ThemeDisplay.getLanguageId();
 
 			if (uuid === structure.uuid) {
 				return {
@@ -600,7 +600,7 @@ function reducer(state: State, action: Action): State {
 					renamingItemUuid: null,
 					structure: {
 						...structure,
-						label: {...structure.label, [defaultLanguageId]: name},
+						label: {...structure.label, [languageId]: name},
 					},
 				};
 			}
@@ -614,7 +614,7 @@ function reducer(state: State, action: Action): State {
 			const children = updateChild({
 				child: {
 					...child,
-					label: {...child.label, [defaultLanguageId]: name},
+					label: {...child.label, [languageId]: name},
 				},
 				root: structure,
 			});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/field.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/field.ts
@@ -223,6 +223,8 @@ export function getDefaultField({
 		label: {
 			[Liferay.ThemeDisplay.getDefaultLanguageId()]:
 				label ?? FIELD_TYPE_LABEL[type],
+			[Liferay.ThemeDisplay.getLanguageId()]:
+				label ?? FIELD_TYPE_LABEL[type],
 		},
 		localized: true,
 		locked,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/state/addRepeatableGroup.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/state/addRepeatableGroup.ts
@@ -72,6 +72,8 @@ export default function addRepeatableGroup({
 			label: {
 				[Liferay.ThemeDisplay.getDefaultLanguageId()]:
 					DEFAULT_GROUP_LABEL,
+				[Liferay.ThemeDisplay.getLanguageId()]:
+					DEFAULT_GROUP_LABEL,
 			},
 			name: getRandomName({capitalize: true}),
 			parent: groupParent,

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/utils/getLocalizedValue.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/utils/getLocalizedValue.test.ts
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import getLocalizedValue from '../../../../src/main/resources/META-INF/resources/js/common/utils/getLocalizedValue';
+
+describe('getLocalizedValue', () => {
+	let getLanguageIdSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		getLanguageIdSpy = jest.spyOn(
+			Liferay.ThemeDisplay,
+			'getLanguageId'
+		);
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('returns the value at the current language when present', () => {
+		getLanguageIdSpy.mockReturnValue('es_ES');
+
+		expect(
+			getLocalizedValue({
+				en_US: 'Home',
+				es_ES: 'Inicio',
+			} as Liferay.Language.LocalizedValue<string>)
+		).toBe('Inicio');
+	});
+
+	it('falls back to the default language when current language is missing', () => {
+		getLanguageIdSpy.mockReturnValue('es_ES');
+
+		expect(
+			getLocalizedValue({
+				en_US: 'Home',
+			} as Liferay.Language.LocalizedValue<string>)
+		).toBe('Home');
+	});
+
+	it('returns an empty string when both current and default are missing', () => {
+		getLanguageIdSpy.mockReturnValue('es_ES');
+
+		expect(
+			getLocalizedValue({
+				fr_FR: 'Maison',
+			} as Liferay.Language.LocalizedValue<string>)
+		).toBe('');
+	});
+
+	it('returns an empty string when value is undefined', () => {
+		expect(
+			getLocalizedValue(
+				undefined as unknown as Liferay.Language.LocalizedValue<string>
+			)
+		).toBe('');
+	});
+
+	it('respects an explicit languageId argument', () => {
+		getLanguageIdSpy.mockReturnValue('es_ES');
+
+		expect(
+			getLocalizedValue(
+				{
+					en_US: 'Home',
+					es_ES: 'Inicio',
+				} as Liferay.Language.LocalizedValue<string>,
+				'en_US'
+			)
+		).toBe('Home');
+	});
+
+	it('falls back to the default language when the explicit languageId is missing', () => {
+		expect(
+			getLocalizedValue(
+				{
+					en_US: 'Home',
+				} as Liferay.Language.LocalizedValue<string>,
+				'es_ES'
+			)
+		).toBe('Home');
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/contexts/StateContext.reducer.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/contexts/StateContext.reducer.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {act, render} from '@testing-library/react';
+import React, {Dispatch} from 'react';
+
+import {
+	Action,
+	State,
+	StateContextProvider,
+	useSelector,
+	useStateDispatch,
+} from '../../../../src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext';
+import {
+	RepeatableGroup,
+	Structure,
+} from '../../../../src/main/resources/META-INF/resources/js/structure_builder/types/Structure';
+import getUuid from '../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/getUuid';
+
+const STRUCTURE_UUID = getUuid();
+const CHILD_UUID = getUuid();
+
+function buildInitialState({
+	structureLabel,
+	childLabel,
+}: {
+	childLabel: Liferay.Language.LocalizedValue<string>;
+	structureLabel: Liferay.Language.LocalizedValue<string>;
+}): State {
+	const child: RepeatableGroup = {
+		children: new Map(),
+		erc: 'child-erc',
+		label: childLabel,
+		name: 'group',
+		parent: STRUCTURE_UUID,
+		relationshipERC: 'rel-erc',
+		relationshipName: 'rel',
+		type: 'repeatable-group',
+		uuid: CHILD_UUID,
+	};
+
+	const structure: Structure = {
+		children: new Map([[CHILD_UUID, child]]),
+		erc: 'structure-erc',
+		label: structureLabel,
+		name: 'MyStructure',
+		path: '',
+		spaces: 'all',
+		status: 'new',
+		system: false,
+		type: 'L_CMS_CONTENT_STRUCTURES',
+		uuid: STRUCTURE_UUID,
+		workflows: {},
+	};
+
+	return {
+		history: {
+			deletedChildren: [],
+			deletedGroupERCs: [],
+			deletedRelationships: [],
+			modifiedNames: new Set(),
+		},
+		invalids: new Map(),
+		publishedChildren: new Set(),
+		renamingItemUuid: null,
+		selection: [],
+		structure,
+		unsavedChanges: false,
+	};
+}
+
+type Refs = {
+	dispatch?: Dispatch<Action>;
+	state?: State;
+};
+
+function Harness({refs}: {refs: Refs}) {
+	refs.state = useSelector((s) => s);
+	refs.dispatch = useStateDispatch();
+
+	return null;
+}
+
+function renderWithState(initialState: State) {
+	const refs: Refs = {};
+
+	render(
+		<StateContextProvider initialState={initialState}>
+			<Harness refs={refs} />
+		</StateContextProvider>
+	);
+
+	return refs;
+}
+
+describe('StateContext reducer — rename-item', () => {
+	let getLanguageIdSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		getLanguageIdSpy = jest.spyOn(
+			Liferay.ThemeDisplay,
+			'getLanguageId'
+		);
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('writes the new label under the current language only, leaving default-language entry intact', () => {
+		getLanguageIdSpy.mockReturnValue('es_ES');
+
+		const refs = renderWithState(
+			buildInitialState({
+				childLabel: {en_US: 'old', es_ES: 'old'} as any,
+				structureLabel: {en_US: 'old', es_ES: 'old'} as any,
+			})
+		);
+
+		act(() => {
+			refs.dispatch!({
+				name: 'new',
+				type: 'rename-item',
+				uuid: STRUCTURE_UUID,
+			});
+		});
+
+		expect(refs.state!.structure.label).toEqual({
+			en_US: 'old',
+			es_ES: 'new',
+		});
+	});
+
+	it('overwrites the single label key when current and default language match', () => {
+		getLanguageIdSpy.mockReturnValue('en_US');
+
+		const refs = renderWithState(
+			buildInitialState({
+				childLabel: {en_US: 'old'} as any,
+				structureLabel: {en_US: 'old'} as any,
+			})
+		);
+
+		act(() => {
+			refs.dispatch!({
+				name: 'new',
+				type: 'rename-item',
+				uuid: STRUCTURE_UUID,
+			});
+		});
+
+		expect(refs.state!.structure.label).toEqual({en_US: 'new'});
+		expect(refs.state!.renamingItemUuid).toBeNull();
+	});
+
+	it('renames a child found by uuid under the current language only', () => {
+		getLanguageIdSpy.mockReturnValue('es_ES');
+
+		const refs = renderWithState(
+			buildInitialState({
+				childLabel: {en_US: 'old', es_ES: 'old'} as any,
+				structureLabel: {en_US: 'root', es_ES: 'root'} as any,
+			})
+		);
+
+		act(() => {
+			refs.dispatch!({
+				name: 'new',
+				type: 'rename-item',
+				uuid: CHILD_UUID,
+			});
+		});
+
+		const child = refs.state!.structure.children.get(
+			CHILD_UUID
+		) as RepeatableGroup;
+
+		expect(child.label).toEqual({en_US: 'old', es_ES: 'new'});
+		expect(refs.state!.structure.label).toEqual({
+			en_US: 'root',
+			es_ES: 'root',
+		});
+	});
+
+	it('leaves labels unchanged when the uuid matches no item', () => {
+		getLanguageIdSpy.mockReturnValue('es_ES');
+
+		const refs = renderWithState(
+			buildInitialState({
+				childLabel: {en_US: 'old', es_ES: 'old'} as any,
+				structureLabel: {en_US: 'root', es_ES: 'root'} as any,
+			})
+		);
+
+		act(() => {
+			refs.dispatch!({
+				name: 'new',
+				type: 'rename-item',
+				uuid: getUuid(),
+			});
+		});
+
+		const child = refs.state!.structure.children.get(
+			CHILD_UUID
+		) as RepeatableGroup;
+
+		expect(child.label).toEqual({en_US: 'old', es_ES: 'old'});
+		expect(refs.state!.structure.label).toEqual({
+			en_US: 'root',
+			es_ES: 'root',
+		});
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/field.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/field.test.ts
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	FIELD_TYPE_LABEL,
+	getDefaultField,
+} from '../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/field';
+import getUuid from '../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/getUuid';
+
+describe('getDefaultField', () => {
+	let getDefaultLanguageIdSpy: jest.SpyInstance;
+	let getLanguageIdSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		getDefaultLanguageIdSpy = jest.spyOn(
+			Liferay.ThemeDisplay,
+			'getDefaultLanguageId'
+		);
+		getLanguageIdSpy = jest.spyOn(
+			Liferay.ThemeDisplay,
+			'getLanguageId'
+		);
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('populates label under both default and current language IDs when they differ', () => {
+		getDefaultLanguageIdSpy.mockReturnValue('en_US');
+		getLanguageIdSpy.mockReturnValue('es_ES');
+
+		const field = getDefaultField({
+			label: 'My Label',
+			parent: getUuid(),
+			type: 'text',
+		});
+
+		expect(field.label).toEqual({
+			en_US: 'My Label',
+			es_ES: 'My Label',
+		});
+	});
+
+	it('produces a single label key when current and default language match', () => {
+		getDefaultLanguageIdSpy.mockReturnValue('en_US');
+		getLanguageIdSpy.mockReturnValue('en_US');
+
+		const field = getDefaultField({
+			label: 'My Label',
+			parent: getUuid(),
+			type: 'text',
+		});
+
+		expect(Object.keys(field.label)).toEqual(['en_US']);
+		expect(field.label.en_US).toBe('My Label');
+	});
+
+	it('falls back to FIELD_TYPE_LABEL when no label is provided', () => {
+		getDefaultLanguageIdSpy.mockReturnValue('en_US');
+		getLanguageIdSpy.mockReturnValue('es_ES');
+
+		const field = getDefaultField({
+			parent: getUuid(),
+			type: 'text',
+		});
+
+		expect(field.label).toEqual({
+			en_US: FIELD_TYPE_LABEL.text,
+			es_ES: FIELD_TYPE_LABEL.text,
+		});
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/state/addRepeatableGroup.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/state/addRepeatableGroup.test.ts
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	RepeatableGroup,
+	Structure,
+} from '../../../../../src/main/resources/META-INF/resources/js/structure_builder/types/Structure';
+import getUuid from '../../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/getUuid';
+import addRepeatableGroup from '../../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/state/addRepeatableGroup';
+
+const ROOT_UUID = getUuid();
+const GROUP_UUID = getUuid();
+
+const ROOT: Structure = {
+	children: new Map(),
+	erc: 'root-erc',
+	label: {},
+	name: 'Root',
+	path: '',
+	spaces: 'all',
+	status: 'new',
+	system: false,
+	type: 'L_CMS_CONTENT_STRUCTURES',
+	uuid: ROOT_UUID,
+	workflows: {},
+};
+
+describe('addRepeatableGroup', () => {
+	let getDefaultLanguageIdSpy: jest.SpyInstance;
+	let getLanguageIdSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		getDefaultLanguageIdSpy = jest.spyOn(
+			Liferay.ThemeDisplay,
+			'getDefaultLanguageId'
+		);
+		getLanguageIdSpy = jest.spyOn(
+			Liferay.ThemeDisplay,
+			'getLanguageId'
+		);
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('populates the new group label under both default and current language IDs', () => {
+		getDefaultLanguageIdSpy.mockReturnValue('en_US');
+		getLanguageIdSpy.mockReturnValue('es_ES');
+
+		const children = addRepeatableGroup({
+			groupChildren: [],
+			groupParent: ROOT_UUID,
+			groupUuid: GROUP_UUID,
+			root: ROOT,
+		});
+
+		const group = children.get(GROUP_UUID) as RepeatableGroup;
+
+		expect(group).toBeDefined();
+		expect(group.type).toBe('repeatable-group');
+		expect(group.label).toEqual({
+			en_US: 'repeatable-group',
+			es_ES: 'repeatable-group',
+		});
+	});
+
+	it('produces a single label key when current and default language match', () => {
+		getDefaultLanguageIdSpy.mockReturnValue('en_US');
+		getLanguageIdSpy.mockReturnValue('en_US');
+
+		const children = addRepeatableGroup({
+			groupChildren: [],
+			groupParent: ROOT_UUID,
+			groupUuid: GROUP_UUID,
+			root: ROOT,
+		});
+
+		const group = children.get(GROUP_UUID) as RepeatableGroup;
+
+		expect(Object.keys(group.label)).toEqual(['en_US']);
+		expect(group.label.en_US).toBe('repeatable-group');
+	});
+});


### PR DESCRIPTION
This PR fixes the localization issues in the CMS (LPD-84651).

The following changes were made:

Updated the localization utilities and components to correctly handle and default to the user's current language.
Added comprehensive translations to the CMS site initializer JSON files (navigation menus, layouts, roles, and object definitions) across all supported languages.
Jira Ticket: https://liferay.atlassian.net/browse/LPD-84651

resend of https://github.com/liferay-commerce/liferay-portal/pull/7301