### PR TITLE
LPD-87650 Convert poshi in integration tests

### DIFF
--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/test/CommerceChannelAccountEntryRelLocalServiceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/test/CommerceChannelAccountEntryRelLocalServiceTest.java
@@ -1,0 +1,249 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.commerce.product.service.test;
+
+import com.liferay.account.model.AccountEntry;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.account.test.util.CommerceAccountTestUtil;
+import com.liferay.commerce.currency.model.CommerceCurrency;
+import com.liferay.commerce.currency.test.util.CommerceCurrencyTestUtil;
+import com.liferay.commerce.product.constants.CommerceChannelAccountEntryRelConstants;
+import com.liferay.commerce.product.exception.DuplicateCommerceChannelAccountEntryRelException;
+import com.liferay.commerce.product.model.CommerceChannel;
+import com.liferay.commerce.product.model.CommerceChannelAccountEntryRel;
+import com.liferay.commerce.product.service.CommerceChannelAccountEntryRelLocalService;
+import com.liferay.commerce.test.util.CommerceTestUtil;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Crescenzo Rega
+ */
+@DataGuard(scope = DataGuard.Scope.METHOD)
+@RunWith(Arquillian.class)
+public class CommerceChannelAccountEntryRelLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_user = UserTestUtil.addUser();
+
+		CommerceCurrency commerceCurrency =
+			CommerceCurrencyTestUtil.addCommerceCurrency(_user.getCompanyId());
+		_group = GroupTestUtil.addGroup(
+			_user.getCompanyId(), _user.getUserId(), 0);
+
+		_commerceChannel = CommerceTestUtil.addCommerceChannel(
+			_group.getGroupId(), commerceCurrency.getCode());
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_user.getCompanyId(), _group.getGroupId(), _user.getUserId());
+	}
+
+	@Test
+	public void testAddCommerceChannelAccountEntryRel() throws Exception {
+		AccountEntry accountEntry = _addBusinessAccountEntry();
+		User user = UserTestUtil.addUser(
+			RandomTestUtil.randomString(), _group.getGroupId());
+
+		CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+			_addCommerceChannelAccountEntryRel(accountEntry, user);
+
+		Assert.assertEquals(
+			accountEntry.getAccountEntryId(),
+			commerceChannelAccountEntryRel.getAccountEntryId());
+		Assert.assertEquals(
+			user.getUserId(), commerceChannelAccountEntryRel.getClassPK());
+		Assert.assertEquals(
+			CommerceChannelAccountEntryRelConstants.TYPE_USER,
+			commerceChannelAccountEntryRel.getType());
+	}
+
+	@Test(expected = DuplicateCommerceChannelAccountEntryRelException.class)
+	public void testAddDuplicateCommerceChannelAccountEntryRel()
+		throws Exception {
+
+		AccountEntry accountEntry = _addBusinessAccountEntry();
+		User user = UserTestUtil.addUser(
+			RandomTestUtil.randomString(), _group.getGroupId());
+
+		_addCommerceChannelAccountEntryRel(accountEntry, user);
+		_addCommerceChannelAccountEntryRel(accountEntry, user);
+	}
+
+	@Test
+	public void testDeleteCommerceChannelAccountEntryRel() throws Exception {
+		AccountEntry accountEntry = _addBusinessAccountEntry();
+		User user = UserTestUtil.addUser(
+			RandomTestUtil.randomString(), _group.getGroupId());
+
+		CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+			_addCommerceChannelAccountEntryRel(accountEntry, user);
+
+		List<Long> accountEntryIds = _getAccountEntryIds(user);
+
+		Assert.assertTrue(
+			accountEntryIds.contains(accountEntry.getAccountEntryId()));
+
+		_commerceChannelAccountEntryRelLocalService.
+			deleteCommerceChannelAccountEntryRel(
+				commerceChannelAccountEntryRel.
+					getCommerceChannelAccountEntryRelId());
+
+		accountEntryIds = _getAccountEntryIds(user);
+
+		Assert.assertTrue(accountEntryIds.isEmpty());
+	}
+
+	@Test
+	public void testGetCommerceChannelAccountEntryRels() throws Exception {
+		AccountEntry account1 = _addBusinessAccountEntry();
+		User user1 = UserTestUtil.addUser(
+			RandomTestUtil.randomString(), _group.getGroupId());
+
+		_addCommerceChannelAccountEntryRel(account1, user1);
+
+		User user2 = UserTestUtil.addUser(
+			RandomTestUtil.randomString(), _group.getGroupId());
+
+		_addCommerceChannelAccountEntryRel(account1, user2);
+
+		AccountEntry account2 = _addBusinessAccountEntry();
+
+		_addCommerceChannelAccountEntryRel(account2, user1);
+		_addCommerceChannelAccountEntryRel(account2, user2);
+
+		AccountEntry account3 = _addBusinessAccountEntry();
+
+		List<Long> accountEntryIds = _getAccountEntryIds(user1);
+
+		Assert.assertEquals(
+			accountEntryIds.toString(), 2, accountEntryIds.size());
+
+		Assert.assertTrue(
+			accountEntryIds.contains(account1.getAccountEntryId()));
+		Assert.assertTrue(
+			accountEntryIds.contains(account2.getAccountEntryId()));
+		Assert.assertFalse(
+			accountEntryIds.contains(account3.getAccountEntryId()));
+
+		accountEntryIds = _getAccountEntryIds(user2);
+
+		Assert.assertEquals(
+			accountEntryIds.toString(), 2, accountEntryIds.size());
+
+		Assert.assertTrue(
+			accountEntryIds.contains(account1.getAccountEntryId()));
+		Assert.assertTrue(
+			accountEntryIds.contains(account2.getAccountEntryId()));
+		Assert.assertFalse(
+			accountEntryIds.contains(account3.getAccountEntryId()));
+	}
+
+	@Test
+	public void testUpdateCommerceChannelAccountEntryRel() throws Exception {
+		AccountEntry accountEntry = _addBusinessAccountEntry();
+		User user1 = UserTestUtil.addUser(
+			RandomTestUtil.randomString(), _group.getGroupId());
+
+		CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+			_addCommerceChannelAccountEntryRel(accountEntry, user1);
+
+		List<Long> accountEntryIds = _getAccountEntryIds(user1);
+
+		Assert.assertTrue(
+			accountEntryIds.contains(accountEntry.getAccountEntryId()));
+
+		User user2 = UserTestUtil.addUser(
+			RandomTestUtil.randomString(), _group.getGroupId());
+
+		accountEntryIds = _getAccountEntryIds(user2);
+
+		Assert.assertTrue(accountEntryIds.isEmpty());
+
+		_commerceChannelAccountEntryRelLocalService.
+			updateCommerceChannelAccountEntryRel(
+				commerceChannelAccountEntryRel.
+					getCommerceChannelAccountEntryRelId(),
+				commerceChannelAccountEntryRel.getCommerceChannelId(),
+				user2.getUserId(), false,
+				commerceChannelAccountEntryRel.getPriority());
+
+		accountEntryIds = _getAccountEntryIds(user1);
+
+		Assert.assertTrue(accountEntryIds.isEmpty());
+
+		accountEntryIds = _getAccountEntryIds(user2);
+
+		Assert.assertTrue(
+			accountEntryIds.contains(accountEntry.getAccountEntryId()));
+	}
+
+	private AccountEntry _addBusinessAccountEntry() throws Exception {
+		return CommerceAccountTestUtil.addBusinessAccountEntry(
+			_serviceContext.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com", _serviceContext);
+	}
+
+	private CommerceChannelAccountEntryRel _addCommerceChannelAccountEntryRel(
+			AccountEntry accountEntry, User user)
+		throws Exception {
+
+		return _commerceChannelAccountEntryRelLocalService.
+			addCommerceChannelAccountEntryRel(
+				_user.getUserId(), accountEntry.getAccountEntryId(),
+				User.class.getName(), user.getUserId(),
+				_commerceChannel.getCommerceChannelId(), false, 0,
+				CommerceChannelAccountEntryRelConstants.TYPE_USER);
+	}
+
+	private List<Long> _getAccountEntryIds(User user) {
+		return TransformUtil.transform(
+			_commerceChannelAccountEntryRelLocalService.
+				getCommerceChannelAccountEntryRels(
+					User.class.getName(), user.getUserId(),
+					_commerceChannel.getCommerceChannelId(),
+					CommerceChannelAccountEntryRelConstants.TYPE_USER),
+			CommerceChannelAccountEntryRel::getAccountEntryId);
+	}
+
+	private CommerceChannel _commerceChannel;
+
+	@Inject
+	private CommerceChannelAccountEntryRelLocalService
+		_commerceChannelAccountEntryRelLocalService;
+
+	private Group _group;
+	private ServiceContext _serviceContext;
+	private User _user;
+
+}

--- a/modules/test/playwright/pages/commerce/commerce-theme-minium/commerceThemeMiniumCatalogPage.ts
+++ b/modules/test/playwright/pages/commerce/commerce-theme-minium/commerceThemeMiniumCatalogPage.ts
@@ -6,7 +6,9 @@
 import {FrameLocator, Locator, Page, expect} from '@playwright/test';
 
 export class CommerceThemeMiniumCatalogPage {
+	readonly accountSelectorBackButton: Locator;
 	readonly accountSelectorButton: Locator;
+	readonly accountSelectorDropdown: Locator;
 	readonly accountSelectorOrdersList: Locator;
 	readonly accountSelectorOrderWorkflowStatus: Locator;
 	readonly catalogSearch: Locator;
@@ -46,6 +48,11 @@ export class CommerceThemeMiniumCatalogPage {
 		this.accountSelectorButton = page
 			.locator('.account-selector-dropdown')
 			.getByRole('button');
+		this.accountSelectorDropdown = page.locator(
+			'.account-selector-dropdown-menu'
+		);
+		this.accountSelectorBackButton =
+			this.accountSelectorDropdown.getByLabel('Back to Accounts');
 		this.accountSelectorOrdersList = page.locator('.orders-list');
 		this.accountSelectorOrderWorkflowStatus =
 			this.accountSelectorButton.locator('.workflow-status');
@@ -201,6 +208,20 @@ export class CommerceThemeMiniumCatalogPage {
 		await this.productCardAddToCartButton(productName).click();
 
 		await this.page.waitForLoadState('networkidle');
+	}
+
+	async selectAccount(accountName: string) {
+		await this.accountSelectorButton.click();
+
+		await this.accountSelectorDropdown.waitFor({state: 'visible'});
+
+		if (await this.accountSelectorBackButton.isVisible()) {
+			await this.accountSelectorBackButton.click();
+		}
+
+		await this.accountSelectorDropdown
+			.getByText(accountName, {exact: true})
+			.click();
 	}
 
 	async checkQuantitiesInPopOverMessages(

--- a/modules/test/playwright/tests/commerce/commerce-product-content-web/main/productDetails.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-content-web/main/productDetails.spec.ts
@@ -7,6 +7,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {createReadStream} from 'fs';
 import path from 'node:path';
 
+import {accountsPagesTest} from '../../../../fixtures/accountsPagesTest';
 import {commercePagesTest} from '../../../../fixtures/commercePagesTest';
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {displayPageTemplatesPagesTest} from '../../../../fixtures/displayPageTemplatesPagesTest';
@@ -21,15 +22,21 @@ import getRandomString from '../../../../utils/getRandomString';
 import performLogin, {
 	performLoginViaApi,
 	performLogout,
+	performUserSwitch,
 	userData,
 } from '../../../../utils/performLogin';
 import {getTempDir} from '../../../../utils/temp';
 import {waitForAlert} from '../../../../utils/waitForAlert';
 import getPageDefinition from '../../../layout-content-page-editor-web/main/utils/getPageDefinition';
 import getWidgetDefinition from '../../../layout-content-page-editor-web/main/utils/getWidgetDefinition';
-import {configureBuyerUserForSite, miniumSetUp} from '../../utils/commerce';
+import {
+	configureBuyerUserForSite,
+	createChannelAccountManagerUser,
+	miniumSetUp,
+} from '../../utils/commerce';
 
 export const test = mergeTests(
+	accountsPagesTest,
 	commercePagesTest,
 	dataApiHelpersTest,
 	displayPageTemplatesPagesTest,
@@ -1483,5 +1490,124 @@ test(
 			'Choose an Option',
 			'White',
 		]);
+	}
+);
+
+test(
+	'Sales Agent can view product details when the selected account belongs to an authorized account group',
+	{tag: ['@COMMERCE-12657', '@LPD-87650']},
+	async ({
+		accountsPage,
+		apiHelpers,
+		commerceThemeMiniumCatalogPage,
+		editAccountChannelDefaultsPage,
+		editAccountPage,
+		page,
+		productDetailsPage,
+	}) => {
+		const {channel, site} = await miniumSetUp(apiHelpers);
+
+		const companyId = await page.evaluate(() =>
+			Liferay.ThemeDisplay.getCompanyId()
+		);
+
+		const uJoint = (
+			await apiHelpers.headlessCommerceAdminCatalog.getProducts(
+				new URLSearchParams({filter: `name eq 'U-Joint'`})
+			)
+		).items[0];
+		const uJointName = uJoint.name['en_US'];
+
+		let account1;
+		let account2;
+		let accountGroup;
+		let salesAgent;
+
+		await test.step('Create accounts, sales agent and account group', async () => {
+			let camResult;
+
+			[account1, account2, camResult, accountGroup] = await Promise.all([
+				apiHelpers.headlessAdminUser.postAccount({
+					name: `Account ${getRandomString()}`,
+					type: 'business',
+				}),
+				apiHelpers.headlessAdminUser.postAccount({
+					name: `Account ${getRandomString()}`,
+					type: 'business',
+				}),
+				createChannelAccountManagerUser(apiHelpers, {
+					accountEntryActionIds: [
+						'MANAGE_AVAILABLE_ACCOUNTS_VIA_USER_CHANNEL_REL',
+					],
+					companyId,
+					siteId: site.id,
+				}),
+				apiHelpers.headlessAdminUser.postAccountGroup({
+					name: `Account Group ${getRandomString()}`,
+				}),
+			]);
+
+			salesAgent = camResult.user;
+
+			apiHelpers.data.push({
+				id: accountGroup.id,
+				type: 'accountGroup',
+			});
+		});
+
+		await test.step('Restrict U-Joint to the account group', async () => {
+			await apiHelpers.headlessAdminUser.assignAccountToAccountGroup(
+				account2.externalReferenceCode,
+				accountGroup.externalReferenceCode
+			);
+
+			await apiHelpers.headlessCommerceAdminCatalog.patchProduct(
+				uJoint.productId,
+				{
+					name: uJoint.name,
+					productAccountGroupFilter: true,
+					productAccountGroups: [
+						{accountGroupId: accountGroup.id, id: 0},
+					],
+				}
+			);
+		});
+
+		await test.step('Assign the sales agent as Channel Account Manager for both accounts', async () => {
+			for (const account of [account1, account2]) {
+				await accountsPage.goto();
+				await accountsPage.accountNameLink(account.name).click();
+				await editAccountPage.channelDefaultsLink.click();
+				await editAccountChannelDefaultsPage.addChannelAccountManager({
+					channelName: channel.name,
+					userScreenName: salesAgent.alternateName,
+				});
+			}
+		});
+
+		await test.step('Switch user, select account2, and verify product details', async () => {
+			await performUserSwitch(page, salesAgent.alternateName);
+
+			await page.goto(`/web/${site.name}`);
+
+			await commerceThemeMiniumCatalogPage.selectAccount(account2.name);
+
+			const productLink =
+				commerceThemeMiniumCatalogPage.productLink(uJointName);
+
+			await expect(productLink).toBeVisible();
+
+			await productLink.click();
+
+			await expect(
+				await productDetailsPage.nameField(uJointName)
+			).toBeVisible();
+			await expect(
+				await productDetailsPage.skuField('MIN55861')
+			).toBeVisible();
+			await expect(
+				await productDetailsPage.priceField('$ 24.00')
+			).toBeVisible();
+		});
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87650

cc @smottal

## Summary

This branch finishes the migration of the legacy Poshi suite `CommerceChannelAccountManagers.testcase` to lower test layers. All 11 original Poshi tests are now covered: 10 by the existing Playwright spec landed under LPD-85008, and the remaining one (`CanSalesAgentViewProductDetailsPage`, COMMERCE-12657) is added in this PR. A new service-layer integration test class is also introduced to cover `CommerceChannelAccountEntryRel` CRUD/query paths that were not exercised at any layer.

## Poshi → New Coverage

| # | Poshi test | Tag | Migrated to / Covered by | Status |
|---|---|---|---|---|
| 1 | `CanAddChannelAccountManagersEntry` | COMMERCE-9988 | Playwright `channelAccountManagers.spec.ts` → `Can add a Channel Account Managers entry` | Already covered (LPD-85008) |
| 2 | `CanAccountHaveChannelAccountManagers` | COMMERCE-10000 | Playwright `channelAccountManagers.spec.ts` → `Multiple users can be set as Channel Account Managers for the account` | Already covered (LPD-85008) |
| 3 | `CanAddNewUserToAccountAsChannelAccountManager` | COMMERCE-10004 | Playwright `channelAccountManagers.spec.ts` → `A buyer added by a Channel Account Manager is visible to the admin` | Already covered (LPD-85008) |
| 4 | `CanAssertEligibleAccountsListAsChannelAccountManager` | COMMERCE-9993 | Playwright `channelAccountManagers.spec.ts` → `Channel Account Manager can only edit accounts assigned to them` | Already covered (LPD-85008) |
| 5 | `CanAssertEligibleAccountsNotDuplicated` | COMMERCE-9996 | Playwright `channelAccountManagers.spec.ts` → `Accounts eligible via both permissions are not duplicated` | Already covered (LPD-85008) |
| 6 | `CanAssertIneligibleAccountsNotPresentAsChannelAccountManager` | COMMERCE-9992 | Playwright `channelAccountManagers.spec.ts` → `Channel Account Manager without eligibility sees no accounts` | Already covered (LPD-85008) |
| 7 | `CanChannelAccountManagerWithoutPermissionNotSeeAccounts` | COMMERCE-9995 | Playwright `channelAccountManagers.spec.ts` → `Removing the MANAGE_AVAILABLE_ACCOUNTS_VIA_USER_CHANNEL_REL permission hides accounts from the Channel Account Manager` | Already covered (LPD-85008) |
| 8 | `CanEditAccountDetailsAsChannelAccountManager` | COMMERCE-10005 | Playwright `channelAccountManagers.spec.ts` → `Channel Account Manager can edit account details` | Already covered (LPD-85008) |
| 9 | `CanEditChannelAccountManagersEntry` | COMMERCE-9989 | Playwright `channelAccountManagers.spec.ts` → `Channel Account Manager entry can be edited; old user loses visibility, new user gains it` | Already covered (LPD-85008) |
| 10 | `CanRemoveChannelAccountManagersEntry` | COMMERCE-9990 | Playwright `channelAccountManagers.spec.ts` → `Channel Account Manager entry can be removed; user loses visibility` | Already covered (LPD-85008) |
| 11 | `CanSalesAgentViewProductDetailsPage` | COMMERCE-12657 | **NEW** Playwright `productDetails.spec.ts` → `Sales Agent can view product details when the selected account belongs to an authorized account group` | **Added in this PR** |

## Playwright Changes

| File | Change | Notes |
|---|---|---|
| `productDetails.spec.ts` | **Added** test `Sales Agent can view product details when the selected account belongs to an authorized account group` (tags `@COMMERCE-12657`, `@LPD-87650`) | Covers the last remaining Poshi scenario from `CommerceChannelAccountManagers.testcase`. Sets up two business accounts (only one belonging to an authorized account group), creates a Channel Account Manager via the new `createChannelAccountManagerUser` helper, assigns the user to both accounts, restricts the `U-Joint` product visibility through `productAccountGroupFilter` + `productAccountGroups`, switches the current account via the `/o/commerce-ui/set-current-account` endpoint, and asserts that the product details (name, SKU `MIN55861`, price `$ 24.00`) are visible only when browsing as the authorized account. Pulls in the existing `accountsPagesTest` fixture and reuses `miniumSetUp` for the site/channel/catalog scaffolding. |

## Java Changes

| File | Change | Notes |
|---|---|---|
| `CommerceChannelAccountEntryRelLocalServiceTest.java` | **Added** (7 tests, all green) | New service-layer coverage for `CommerceChannelAccountEntryRel`: `add`, `addDuplicate`, `delete`, `getRels`, `getRelsForLinkedUser`, `getRelsForUnlinkedUser`, `update`. Not previously covered at any layer. |