### PR TITLE
LPD-88196 process keyword consistently in commerce search results contributor

### DIFF
--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSearchResultsPortletSharedSearchContributor.java
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSearchResultsPortletSharedSearchContributor.java
@@ -92,7 +92,10 @@ public class CPSearchResultsPortletSharedSearchContributor
 			WebKeys.THEME_DISPLAY);
 
 		String parameterValue = GetterUtil.getString(
-			portletSharedSearchSettings.getParameter("q"));
+			portletSharedSearchSettings.getParameter(
+				GetterUtil.getString(
+					portletSharedSearchSettings.getKeywordsParameterName(),
+					"q")));
 
 		if (!Validator.isBlank(parameterValue)) {
 			if ((parameterValue.length() > 1) &&

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSearchResultsPortletSharedSearchContributor.java
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSearchResultsPortletSharedSearchContributor.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
@@ -93,14 +94,14 @@ public class CPSearchResultsPortletSharedSearchContributor
 		String parameterValue = GetterUtil.getString(
 			portletSharedSearchSettings.getParameter("q"));
 
-		if (parameterValue != null) {
+		if (!Validator.isBlank(parameterValue)) {
 			if ((parameterValue.length() > 1) &&
 				(parameterValue.charAt(0) == CharPool.STAR)) {
 
 				parameterValue = parameterValue.substring(1);
 			}
 
-			portletSharedSearchSettings.setKeywords(parameterValue.toString());
+			portletSharedSearchSettings.setKeywords(parameterValue);
 		}
 
 		portletSharedSearchSettings.addCondition(

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSearchResultsPortletSharedSearchContributor.java
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSearchResultsPortletSharedSearchContributor.java
@@ -15,6 +15,7 @@ import com.liferay.commerce.product.content.search.web.internal.configuration.CP
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CommerceChannel;
 import com.liferay.commerce.product.service.CommerceChannelLocalService;
+import com.liferay.petra.string.CharPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.dao.search.SearchPaginationUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -89,9 +90,18 @@ public class CPSearchResultsPortletSharedSearchContributor
 		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		portletSharedSearchSettings.setKeywords(
-			GetterUtil.getString(
-				portletSharedSearchSettings.getParameter("q")));
+		String parameterValue = GetterUtil.getString(
+			portletSharedSearchSettings.getParameter("q"));
+
+		if (parameterValue != null) {
+			if ((parameterValue.length() > 1) &&
+				(parameterValue.charAt(0) == CharPool.STAR)) {
+
+				parameterValue = parameterValue.substring(1);
+			}
+
+			portletSharedSearchSettings.setKeywords(parameterValue.toString());
+		}
 
 		portletSharedSearchSettings.addCondition(
 			new BooleanClause<Query>(

--- a/modules/test/playwright/tests/commerce/commerce-product-content-search-web/main/searchResults.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-content-search-web/main/searchResults.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {commercePagesTest} from '../../../../fixtures/commercePagesTest';
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {searchPageTest} from '../../../../fixtures/searchPageTest';
+import getRandomString from '../../../../utils/getRandomString';
+import getPageDefinition from '../../../layout-content-page-editor-web/main/utils/getPageDefinition';
+import getWidgetDefinition from '../../../layout-content-page-editor-web/main/utils/getWidgetDefinition';
+
+export const test = mergeTests(
+	commercePagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	searchPageTest
+);
+
+test(
+	'Search should always properly strip keyword of leading asterisk when searching for a product',
+	{tag: ['@LPD-88196']},
+	async ({apiHelpers, page, searchPage, site}) => {
+		await apiHelpers.headlessCommerceAdminChannel.postChannel({
+			siteGroupId: site.id,
+		});
+
+		const catalog =
+			await apiHelpers.headlessCommerceAdminCatalog.postCatalog();
+
+		const product1 =
+			await apiHelpers.headlessCommerceAdminCatalog.postProduct({
+				catalogId: catalog.id,
+			});
+
+		const product2 =
+			await apiHelpers.headlessCommerceAdminCatalog.postProduct({
+				catalogId: catalog.id,
+			});
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getWidgetDefinition({
+					id: getRandomString(),
+					widgetConfig: {
+						allowEmptySearches: 'true',
+						keywordsParameterName: 'q',
+						searchScope: 'everything',
+					},
+					widgetName:
+						'com_liferay_portal_search_web_search_bar_portlet_SearchBarPortlet',
+				}),
+				getWidgetDefinition({
+					id: getRandomString(),
+					widgetConfig: {
+						allowEmptySearches: 'true',
+					},
+					widgetName:
+						'com_liferay_portal_search_web_search_options_portlet_SearchOptionsPortlet',
+				}),
+				getWidgetDefinition({
+					id: getRandomString(),
+					widgetName:
+						'com_liferay_commerce_product_content_search_web_internal_portlet_CPSearchResultsPortlet',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await page.goto(`/web/${site.name}/${layout.friendlyUrlPath}`);
+
+		await expect(page.getByText(product1.name.en_US)).toBeVisible();
+
+		await expect(page.getByText(product2.name.en_US)).toBeVisible();
+
+		await page.goto(
+			`/web/${site.name}/${layout.friendlyUrlPath}?q=*(cpProductId:${product1.productId})`
+		);
+
+		await expect(page.getByText(product1.name.en_US)).toBeVisible();
+
+		await expect(page.getByText(product2.name.en_US)).not.toBeVisible();
+
+		await searchPage.searchBarInputInMainContent.fill(
+			`*(cpProductId:${product2.productId})`
+		);
+		await searchPage.searchBarInputInMainContent.press('Enter');
+
+		await expect(page.getByText(product1.name.en_US)).not.toBeVisible();
+
+		await expect(page.getByText(product2.name.en_US)).toBeVisible();
+	}
+);


### PR DESCRIPTION
Hi @andrea-ale-sbarra ,

https://liferay.atlassian.net/browse/LPD-88196, tied to FIRE LPP.

Fix resolves a potential race condition between two SharedSearchContributors -- CPSearchResults and Depot. Both attempt to process and save the keywords, but CPSearchResults previously saved it as is, while Depot always stripped the beginning asterisk per Keywords.java implementation. Depending on which triggered first, the keyword would potentially have the asterisk still at the beginning which would act as a wildcard and return all potential items. To make the behavior consistent, I've changed it so CPSearchResults will always also strip it when saving the keyword.